### PR TITLE
pytorch 1.0 compatibility

### DIFF
--- a/examples/ode_demo.py
+++ b/examples/ode_demo.py
@@ -42,7 +42,7 @@ with torch.no_grad():
 
 
 def get_batch():
-    s = torch.from_numpy(np.random.choice(np.arange(args.data_size - args.batch_time), args.batch_size, replace=False))
+    s = torch.from_numpy(np.random.choice(np.arange(args.data_size - args.batch_time, dtype=np.int64), args.batch_size, replace=False))
     batch_y0 = true_y[s]  # (M, D)
     batch_t = t[:args.batch_time]  # (T)
     batch_y = torch.stack([true_y[s + i] for i in range(args.batch_time)], dim=0)  # (T, M, D)


### PR DESCRIPTION
Mask s in Line 45 needs to be in long format to be usable by torch 1.0