### PR TITLE
Implementation of adaptive Heun method

### DIFF
--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -58,6 +58,27 @@ class TestCollectionState(unittest.TestCase):
             func = lambda y0, t_points: torchdiffeq.odeint(tuple_f, (y0, y0), t_points, method='adams')[i]
             self.assertTrue(torch.autograd.gradcheck(func, (y0, t_points)))
 
+    def test_adaptive_heun(self):
+        f, y0, t_points, sol = construct_problem(TEST_DEVICE)
+
+        tuple_f = lambda t, y: (f(t, y[0]), f(t, y[1]))
+        tuple_y0 = (y0, y0)
+
+        tuple_y = torchdiffeq.odeint(tuple_f, tuple_y0, t_points, method='adaptive_heun')
+        max_error0 = (sol - tuple_y[0]).max()
+        max_error1 = (sol - tuple_y[1]).max()
+        self.assertLess(max_error0, eps)
+        self.assertLess(max_error1, eps)
+
+    def test_adaptive_heun_gradient(self):
+        f, y0, t_points, sol = construct_problem(TEST_DEVICE)
+
+        tuple_f = lambda t, y: (f(t, y[0]), f(t, y[1]))
+
+        for i in range(2):
+            func = lambda y0, t_points: torchdiffeq.odeint(tuple_f, (y0, y0), t_points, method='adaptive_heun')[i]
+            self.assertTrue(torch.autograd.gradcheck(func, (y0, t_points)))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/gradient_tests.py
+++ b/tests/gradient_tests.py
@@ -42,6 +42,12 @@ class TestGradient(unittest.TestCase):
         func = lambda y0, t_points: torchdiffeq.odeint(f, y0, t_points, method='adams')
         self.assertTrue(torch.autograd.gradcheck(func, (y0, t_points)))
 
+    def test_adaptive_heun(self):
+        f, y0, t_points, _ = construct_problem(TEST_DEVICE)
+
+        func = lambda y0, t_points: torchdiffeq.odeint(f, y0, t_points, method='adaptive_heun')
+        self.assertTrue(torch.autograd.gradcheck(func, (y0, t_points)))
+
     def test_adjoint(self):
         """
         Test against dopri5

--- a/tests/odeint_tests.py
+++ b/tests/odeint_tests.py
@@ -58,6 +58,13 @@ class TestSolverError(unittest.TestCase):
             with self.subTest(ode=ode):
                 self.assertLess(rel_error(sol, y), error_tol)
 
+    def test_adaptive_heun(self):
+        for ode in problems.PROBLEMS.keys():
+            f, y0, t_points, sol = problems.construct_problem(TEST_DEVICE, ode=ode)
+            y = torchdiffeq.odeint(f, y0, t_points, method='adaptive_heun')
+            with self.subTest(ode=ode):
+                self.assertLess(rel_error(sol, y), error_tol)
+
     def test_adjoint(self):
         for ode in problems.PROBLEMS.keys():
             f, y0, t_points, sol = problems.construct_problem(TEST_DEVICE, reverse=True)

--- a/tests/odeint_tests.py
+++ b/tests/odeint_tests.py
@@ -116,6 +116,14 @@ class TestSolverBackwardsInTimeError(unittest.TestCase):
             with self.subTest(ode=ode):
                 self.assertLess(rel_error(sol, y), error_tol)
 
+    def test_adaptive_heun(self):
+        for ode in problems.PROBLEMS.keys():
+            f, y0, t_points, sol = problems.construct_problem(TEST_DEVICE, reverse=True)
+
+            y = torchdiffeq.odeint(f, y0, t_points, method='adaptive_heun')
+            with self.subTest(ode=ode):
+                self.assertLess(rel_error(sol, y), error_tol)
+
     def test_adjoint(self):
         for ode in problems.PROBLEMS.keys():
             f, y0, t_points, sol = problems.construct_problem(TEST_DEVICE, reverse=True)
@@ -155,6 +163,12 @@ class TestNoIntegration(unittest.TestCase):
         f, y0, t_points, sol = problems.construct_problem(TEST_DEVICE, reverse=True)
 
         y = torchdiffeq.odeint(f, y0, t_points[0:1], method='dopri5')
+        self.assertLess(max_abs(sol[0] - y), error_tol)
+
+    def test_dopri5(self):
+        f, y0, t_points, sol = problems.construct_problem(TEST_DEVICE, reverse=True)
+
+        y = torchdiffeq.odeint(f, y0, t_points[0:1], method='adaptive_heun')
         self.assertLess(max_abs(sol[0] - y), error_tol)
 
 

--- a/torchdiffeq/_impl/adaptive_heun.py
+++ b/torchdiffeq/_impl/adaptive_heun.py
@@ -13,10 +13,10 @@ _ADAPTIVE_HEUN_TABLEAU = _ButcherTableau(
     beta=[
         [1.],
     ],
-    c_sol=[1 / 2, 1 / 2],
+    c_sol=[0.5, 0.5],
     c_error=[
-        1. - 1 / 2,
-        0. - 1 / 2,
+        0.5,
+        -0.5,
     ],
 )
 

--- a/torchdiffeq/_impl/adaptive_heun.py
+++ b/torchdiffeq/_impl/adaptive_heun.py
@@ -1,0 +1,111 @@
+# Based on https://github.com/tensorflow/tensorflow/tree/master/tensorflow/contrib/integrate
+import torch
+from .misc import (
+    _scaled_dot_product, _convert_to_tensor, _is_finite, _select_initial_step, _handle_unused_kwargs, _is_iterable,
+    _optimal_step_size, _compute_error_ratio
+)
+from .solvers import AdaptiveStepsizeODESolver
+from .interp import _interp_fit, _interp_evaluate
+from .rk_common import _RungeKuttaState, _ButcherTableau, _runge_kutta_step
+
+_ADAPTIVE_HEUN_TABLEAU = _ButcherTableau(
+    alpha=[1.],
+    beta=[
+        [1.],
+    ],
+    c_sol=[1 / 2, 1 / 2],
+    c_error=[
+        1. - 1 / 2,
+        0. - 1 / 2,
+    ],
+)
+
+AH_C_MID = [
+    1., 0.
+]
+
+
+def _interp_fit_adaptive_heun(y0, y1, k, dt, tableau=_ADAPTIVE_HEUN_TABLEAU):
+    """Fit an interpolating polynomial to the results of a Runge-Kutta step."""
+    dt = dt.type_as(y0[0])
+    y_mid = tuple(y0_ + _scaled_dot_product(dt, AH_C_MID, k_) for y0_, k_ in zip(y0, k))
+    f0 = tuple(k_[0] for k_ in k)
+    f1 = tuple(k_[-1] for k_ in k)
+    return _interp_fit(y0, y1, y_mid, f0, f1, dt)
+
+
+def _abs_square(x):
+    return torch.mul(x, x)
+
+
+def _ta_append(list_of_tensors, value):
+    """Append a value to the end of a list of PyTorch tensors."""
+    list_of_tensors.append(value)
+    return list_of_tensors
+
+
+class AdaptiveHeunSolver(AdaptiveStepsizeODESolver):
+
+    def __init__(
+        self, func, y0, rtol, atol, first_step=None, safety=0.9, ifactor=10.0, dfactor=0.2, max_num_steps=2**31 - 1,
+        **unused_kwargs
+    ):
+        _handle_unused_kwargs(self, unused_kwargs)
+        del unused_kwargs
+
+        self.func = func
+        self.y0 = y0
+        self.rtol = rtol if _is_iterable(rtol) else [rtol] * len(y0)
+        self.atol = atol if _is_iterable(atol) else [atol] * len(y0)
+        self.first_step = first_step
+        self.safety = _convert_to_tensor(safety, dtype=torch.float64, device=y0[0].device)
+        self.ifactor = _convert_to_tensor(ifactor, dtype=torch.float64, device=y0[0].device)
+        self.dfactor = _convert_to_tensor(dfactor, dtype=torch.float64, device=y0[0].device)
+        self.max_num_steps = _convert_to_tensor(max_num_steps, dtype=torch.int32, device=y0[0].device)
+
+    def before_integrate(self, t):
+        f0 = self.func(t[0].type_as(self.y0[0]), self.y0)
+        if self.first_step is None:
+            first_step = _select_initial_step(self.func, t[0], self.y0, 4, self.rtol[0], self.atol[0], f0=f0).to(t)
+        else:
+            first_step = _convert_to_tensor(0.01, dtype=t.dtype, device=t.device)
+        self.rk_state = _RungeKuttaState(self.y0, f0, t[0], t[0], first_step, interp_coeff=[self.y0] * 5)
+
+    def advance(self, next_t):
+        """Interpolate through the next time point, integrating as necessary."""
+        n_steps = 0
+        while next_t > self.rk_state.t1:
+            assert n_steps < self.max_num_steps, 'max_num_steps exceeded ({}>={})'.format(n_steps, self.max_num_steps)
+            self.rk_state = self._adaptive_dopri5_step(self.rk_state)
+            n_steps += 1
+        return _interp_evaluate(self.rk_state.interp_coeff, self.rk_state.t0, self.rk_state.t1, next_t)
+
+    def _adaptive_heun_step(self, rk_state):
+        """Take an adaptive Runge-Kutta step to integrate the ODE."""
+        y0, f0, _, t0, dt, interp_coeff = rk_state
+        ########################################################
+        #                      Assertions                      #
+        ########################################################
+        assert t0 + dt > t0, 'underflow in dt {}'.format(dt.item())
+        for y0_ in y0:
+            assert _is_finite(torch.abs(y0_)), 'non-finite values in state `y`: {}'.format(y0_)
+        y1, f1, y1_error, k = _runge_kutta_step(self.func, y0, f0, t0, dt, tableau=_DORMAND_PRINCE_SHAMPINE_TABLEAU)
+
+        ########################################################
+        #                     Error Ratio                      #
+        ########################################################
+        mean_sq_error_ratio = _compute_error_ratio(y1_error, atol=self.atol, rtol=self.rtol, y0=y0, y1=y1)
+        accept_step = (torch.tensor(mean_sq_error_ratio) <= 1).all()
+
+        ########################################################
+        #                   Update RK State                    #
+        ########################################################
+        y_next = y1 if accept_step else y0
+        f_next = f1 if accept_step else f0
+        t_next = t0 + dt if accept_step else t0
+        interp_coeff = _interp_fit_adaptive_heun(y0, y1, k, dt) if accept_step else interp_coeff
+        dt_next = _optimal_step_size(
+            dt, mean_sq_error_ratio, safety=self.safety, ifactor=self.ifactor, dfactor=self.dfactor, order=5
+        )
+        rk_state = _RungeKuttaState(y_next, f_next, t0, t_next, dt_next, interp_coeff)
+        return rk_state

--- a/torchdiffeq/_impl/adaptive_heun.py
+++ b/torchdiffeq/_impl/adaptive_heun.py
@@ -21,7 +21,7 @@ _ADAPTIVE_HEUN_TABLEAU = _ButcherTableau(
 )
 
 AH_C_MID = [
-    1., 0.
+    0.5, 0.
 ]
 
 
@@ -76,7 +76,7 @@ class AdaptiveHeunSolver(AdaptiveStepsizeODESolver):
         n_steps = 0
         while next_t > self.rk_state.t1:
             assert n_steps < self.max_num_steps, 'max_num_steps exceeded ({}>={})'.format(n_steps, self.max_num_steps)
-            self.rk_state = self._adaptive_dopri5_step(self.rk_state)
+            self.rk_state = self._adaptive_heun_step(self.rk_state)
             n_steps += 1
         return _interp_evaluate(self.rk_state.interp_coeff, self.rk_state.t0, self.rk_state.t1, next_t)
 
@@ -89,7 +89,7 @@ class AdaptiveHeunSolver(AdaptiveStepsizeODESolver):
         assert t0 + dt > t0, 'underflow in dt {}'.format(dt.item())
         for y0_ in y0:
             assert _is_finite(torch.abs(y0_)), 'non-finite values in state `y`: {}'.format(y0_)
-        y1, f1, y1_error, k = _runge_kutta_step(self.func, y0, f0, t0, dt, tableau=_DORMAND_PRINCE_SHAMPINE_TABLEAU)
+        y1, f1, y1_error, k = _runge_kutta_step(self.func, y0, f0, t0, dt, tableau=_ADAPTIVE_HEUN_TABLEAU)
 
         ########################################################
         #                     Error Ratio                      #

--- a/torchdiffeq/_impl/odeint.py
+++ b/torchdiffeq/_impl/odeint.py
@@ -1,5 +1,6 @@
 from .tsit5 import Tsit5Solver
 from .dopri5 import Dopri5Solver
+from .adaptive_heun import AdaptiveHeunSolver
 from .fixed_grid import Euler, Midpoint, RK4
 from .fixed_adams import AdamsBashforth, AdamsBashforthMoulton
 from .adams import VariableCoefficientAdamsBashforth
@@ -14,6 +15,7 @@ SOLVERS = {
     'euler': Euler,
     'midpoint': Midpoint,
     'rk4': RK4,
+    'adaptive_heun': AdaptiveHeunSolver,
 }
 
 


### PR DESCRIPTION
This is the implementation of the adaptive Heun method; an adaptive Runge-Kutta method of order 2(1). The method can for example be found in the textbook from Butcher https://uotechnology.edu.iq/dep-production/branch1_files/Numerical%20Methods%20for%20Ordinary%20Differential%20Equations%20-%20J.%20C.%20Butcher.pdf on page 205 or here https://en.wikipedia.org/wiki/Runge%E2%80%93Kutta_methods.

I am not entirely sure if the values AH_C_MID are optimal, but they seemed to pass all the tests. The values are chosen according to Formula (beneath) 3.1 of https://www.jstor.org/stable/pdf/2008219.pdf?refreqid=excelsior%3A7afd17f66199db78ea46c57aede1efa2.

Cheers,

Tim