### PR TITLE
Bogacki-Shampine solver (MATLAB's ode23), and first_step bug fix

### DIFF
--- a/torchdiffeq/_impl/adams.py
+++ b/torchdiffeq/_impl/adams.py
@@ -61,7 +61,7 @@ def compute_implicit_phi(explicit_phi, f_n, k):
 class VariableCoefficientAdamsBashforth(AdaptiveStepsizeODESolver):
 
     def __init__(
-        self, func, y0, rtol, atol, implicit=True, max_order=_MAX_ORDER, safety=0.9, ifactor=10.0, dfactor=0.2,
+        self, func, y0, rtol, atol, implicit=True, first_step=None, max_order=_MAX_ORDER, safety=0.9, ifactor=10.0, dfactor=0.2,
         **unused_kwargs
     ):
         _handle_unused_kwargs(self, unused_kwargs)
@@ -72,6 +72,7 @@ class VariableCoefficientAdamsBashforth(AdaptiveStepsizeODESolver):
         self.rtol = rtol if _is_iterable(rtol) else [rtol] * len(y0)
         self.atol = atol if _is_iterable(atol) else [atol] * len(y0)
         self.implicit = implicit
+        self.first_step = first_step
         self.max_order = int(max(_MIN_ORDER, min(max_order, _MAX_ORDER)))
         self.safety = _convert_to_tensor(safety, dtype=torch.float64, device=y0[0].device)
         self.ifactor = _convert_to_tensor(ifactor, dtype=torch.float64, device=y0[0].device)
@@ -87,7 +88,10 @@ class VariableCoefficientAdamsBashforth(AdaptiveStepsizeODESolver):
         prev_t.appendleft(t0)
         prev_f.appendleft(f0)
         phi.appendleft(f0)
-        first_step = _select_initial_step(self.func, t[0], self.y0, 2, self.rtol[0], self.atol[0], f0=f0).to(t)
+        if self.first_step is None:
+            first_step = _select_initial_step(self.func, t[0], self.y0, 2, self.rtol[0], self.atol[0], f0=f0).to(t)
+        else:
+            first_step = _select_initial_step(self.func, t[0], self.y0, 2, self.rtol[0], self.atol[0], f0=f0).to(t)
 
         self.vcabm_state = _VCABMState(self.y0, prev_f, prev_t, next_t=t[0] + first_step, phi=phi, order=1)
 

--- a/torchdiffeq/_impl/adaptive_heun.py
+++ b/torchdiffeq/_impl/adaptive_heun.py
@@ -66,9 +66,9 @@ class AdaptiveHeunSolver(AdaptiveStepsizeODESolver):
     def before_integrate(self, t):
         f0 = self.func(t[0].type_as(self.y0[0]), self.y0)
         if self.first_step is None:
-            first_step = _select_initial_step(self.func, t[0], self.y0, 4, self.rtol[0], self.atol[0], f0=f0).to(t)
+            first_step = _select_initial_step(self.func, t[0], self.y0, 1, self.rtol[0], self.atol[0], f0=f0).to(t)
         else:
-            first_step = _convert_to_tensor(0.01, dtype=t.dtype, device=t.device)
+            first_step = _convert_to_tensor(self.first_step, dtype=t.dtype, device=t.device)
         self.rk_state = _RungeKuttaState(self.y0, f0, t[0], t[0], first_step, interp_coeff=[self.y0] * 5)
 
     def advance(self, next_t):

--- a/torchdiffeq/_impl/bosh3.py
+++ b/torchdiffeq/_impl/bosh3.py
@@ -1,4 +1,3 @@
-# Based on https://github.com/tensorflow/tensorflow/tree/master/tensorflow/contrib/integrate
 import torch
 from .misc import (
     _scaled_dot_product, _convert_to_tensor, _is_finite, _select_initial_step, _handle_unused_kwargs, _is_iterable,
@@ -8,54 +7,31 @@ from .solvers import AdaptiveStepsizeODESolver
 from .interp import _interp_fit, _interp_evaluate
 from .rk_common import _RungeKuttaState, _ButcherTableau, _runge_kutta_step
 
-_DORMAND_PRINCE_SHAMPINE_TABLEAU = _ButcherTableau(
-    alpha=[1 / 5, 3 / 10, 4 / 5, 8 / 9, 1., 1.],
+_BOGACKI_SHAMPINE_TABLEAU = _ButcherTableau(
+    alpha=[1/2, 3/4,  1.],
     beta=[
-        [1 / 5],
-        [3 / 40, 9 / 40],
-        [44 / 45, -56 / 15, 32 / 9],
-        [19372 / 6561, -25360 / 2187, 64448 / 6561, -212 / 729],
-        [9017 / 3168, -355 / 33, 46732 / 5247, 49 / 176, -5103 / 18656],
-        [35 / 384, 0, 500 / 1113, 125 / 192, -2187 / 6784, 11 / 84],
+        [1/2],
+        [0., 3/4],
+        [2/9, 1/3, 4/9]
     ],
-    c_sol=[35 / 384, 0, 500 / 1113, 125 / 192, -2187 / 6784, 11 / 84, 0],
-    c_error=[
-        35 / 384 - 1951 / 21600,
-        0,
-        500 / 1113 - 22642 / 50085,
-        125 / 192 - 451 / 720,
-        -2187 / 6784 - -12231 / 42400,
-        11 / 84 - 649 / 6300,
-        -1. / 60.,
-    ],
+    c_sol=[2/9, 1/3, 4/9, 0.],
+    c_error=[2/9-7/24, 1/3-1/4, 4/9-1/3, -1/8],
 )
 
-DPS_C_MID = [
-    6025192743 / 30085553152 / 2, 0, 51252292925 / 65400821598 / 2, -2691868925 / 45128329728 / 2,
-    187940372067 / 1594534317056 / 2, -1776094331 / 19743644256 / 2, 11237099 / 235043384 / 2
-]
+BS_C_MID = [ 0., 0.5,  0., 0.  ]
 
 
-def _interp_fit_dopri5(y0, y1, k, dt, tableau=_DORMAND_PRINCE_SHAMPINE_TABLEAU):
+def _interp_fit_bosh3(y0, y1, k, dt):
     """Fit an interpolating polynomial to the results of a Runge-Kutta step."""
     dt = dt.type_as(y0[0])
-    y_mid = tuple(y0_ + _scaled_dot_product(dt, DPS_C_MID, k_) for y0_, k_ in zip(y0, k))
+    y_mid = tuple(y0_ + _scaled_dot_product(dt, BS_C_MID, k_) for y0_, k_ in zip(y0, k))
     f0 = tuple(k_[0] for k_ in k)
     f1 = tuple(k_[-1] for k_ in k)
     return _interp_fit(y0, y1, y_mid, f0, f1, dt)
 
 
-def _abs_square(x):
-    return torch.mul(x, x)
 
-
-def _ta_append(list_of_tensors, value):
-    """Append a value to the end of a list of PyTorch tensors."""
-    list_of_tensors.append(value)
-    return list_of_tensors
-
-
-class Dopri5Solver(AdaptiveStepsizeODESolver):
+class Bosh3Solver(AdaptiveStepsizeODESolver):
 
     def __init__(
         self, func, y0, rtol, atol, first_step=None, safety=0.9, ifactor=10.0, dfactor=0.2, max_num_steps=2**31 - 1,
@@ -77,7 +53,7 @@ class Dopri5Solver(AdaptiveStepsizeODESolver):
     def before_integrate(self, t):
         f0 = self.func(t[0].type_as(self.y0[0]), self.y0)
         if self.first_step is None:
-            first_step = _select_initial_step(self.func, t[0], self.y0, 4, self.rtol[0], self.atol[0], f0=f0).to(t)
+            first_step = _select_initial_step(self.func, t[0], self.y0, 2, self.rtol[0], self.atol[0], f0=f0).to(t)
         else:
             first_step = _convert_to_tensor(self.first_step, dtype=t.dtype, device=t.device)
         self.rk_state = _RungeKuttaState(self.y0, f0, t[0], t[0], first_step, interp_coeff=[self.y0] * 5)
@@ -87,11 +63,11 @@ class Dopri5Solver(AdaptiveStepsizeODESolver):
         n_steps = 0
         while next_t > self.rk_state.t1:
             assert n_steps < self.max_num_steps, 'max_num_steps exceeded ({}>={})'.format(n_steps, self.max_num_steps)
-            self.rk_state = self._adaptive_dopri5_step(self.rk_state)
+            self.rk_state = self._adaptive_bosh3_step(self.rk_state)
             n_steps += 1
         return _interp_evaluate(self.rk_state.interp_coeff, self.rk_state.t0, self.rk_state.t1, next_t)
 
-    def _adaptive_dopri5_step(self, rk_state):
+    def _adaptive_bosh3_step(self, rk_state):
         """Take an adaptive Runge-Kutta step to integrate the ODE."""
         y0, f0, _, t0, dt, interp_coeff = rk_state
         ########################################################
@@ -100,7 +76,7 @@ class Dopri5Solver(AdaptiveStepsizeODESolver):
         assert t0 + dt > t0, 'underflow in dt {}'.format(dt.item())
         for y0_ in y0:
             assert _is_finite(torch.abs(y0_)), 'non-finite values in state `y`: {}'.format(y0_)
-        y1, f1, y1_error, k = _runge_kutta_step(self.func, y0, f0, t0, dt, tableau=_DORMAND_PRINCE_SHAMPINE_TABLEAU)
+        y1, f1, y1_error, k = _runge_kutta_step(self.func, y0, f0, t0, dt, tableau=_BOGACKI_SHAMPINE_TABLEAU)
 
         ########################################################
         #                     Error Ratio                      #
@@ -114,9 +90,9 @@ class Dopri5Solver(AdaptiveStepsizeODESolver):
         y_next = y1 if accept_step else y0
         f_next = f1 if accept_step else f0
         t_next = t0 + dt if accept_step else t0
-        interp_coeff = _interp_fit_dopri5(y0, y1, k, dt) if accept_step else interp_coeff
+        interp_coeff = _interp_fit_bosh3(y0, y1, k, dt) if accept_step else interp_coeff
         dt_next = _optimal_step_size(
-            dt, mean_sq_error_ratio, safety=self.safety, ifactor=self.ifactor, dfactor=self.dfactor, order=5
+            dt, mean_sq_error_ratio, safety=self.safety, ifactor=self.ifactor, dfactor=self.dfactor, order=3
         )
         rk_state = _RungeKuttaState(y_next, f_next, t0, t_next, dt_next, interp_coeff)
         return rk_state

--- a/torchdiffeq/_impl/odeint.py
+++ b/torchdiffeq/_impl/odeint.py
@@ -1,5 +1,6 @@
 from .tsit5 import Tsit5Solver
 from .dopri5 import Dopri5Solver
+from .bosh3 import Bosh3Solver
 from .adaptive_heun import AdaptiveHeunSolver
 from .fixed_grid import Euler, Midpoint, RK4
 from .fixed_adams import AdamsBashforth, AdamsBashforthMoulton
@@ -12,6 +13,7 @@ SOLVERS = {
     'adams': VariableCoefficientAdamsBashforth,
     'tsit5': Tsit5Solver,
     'dopri5': Dopri5Solver,
+    'bosh3': Bosh3Solver,
     'euler': Euler,
     'midpoint': Midpoint,
     'rk4': RK4,

--- a/torchdiffeq/_impl/tsit5.py
+++ b/torchdiffeq/_impl/tsit5.py
@@ -86,7 +86,7 @@ class Tsit5Solver(AdaptiveStepsizeODESolver):
         if self.first_step is None:
             first_step = _select_initial_step(self.func, t[0], self.y0, 4, self.rtol, self.atol).to(t)
         else:
-            first_step = _convert_to_tensor(0.01, dtype=t.dtype, device=t.device)
+            first_step = _convert_to_tensor(self.first_step, dtype=t.dtype, device=t.device)
         self.rk_state = _RungeKuttaState(
             self.y0,
             self.func(t[0].type_as(self.y0[0]), self.y0), t[0], t[0], first_step,


### PR DESCRIPTION
Implementation of Bogacki-Shampine RK3(2) solver, essentially equivalent to MATLAB's ode23. Good for medium accuracy and speed, as well as moderately stiff equations.

Also fixes a bug where adaptive solver's initial time step was always being set to 0.01, even when the user specified otherwise.