### PR TITLE
Gridpoints

### DIFF
--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -37,6 +37,27 @@ class TestCollectionState(unittest.TestCase):
             func = lambda y0, t_points: torchdiffeq.odeint(tuple_f, (y0, y0), t_points, method='dopri5')[i]
             self.assertTrue(torch.autograd.gradcheck(func, (y0, t_points)))
 
+    def test_bosh3(self):
+        f, y0, t_points, sol = construct_problem(TEST_DEVICE)
+
+        tuple_f = lambda t, y: (f(t, y[0]), f(t, y[1]))
+        tuple_y0 = (y0, y0)
+
+        tuple_y = torchdiffeq.odeint(tuple_f, tuple_y0, t_points, method='bosh3')
+        max_error0 = (sol - tuple_y[0]).max()
+        max_error1 = (sol - tuple_y[1]).max()
+        self.assertLess(max_error0, eps)
+        self.assertLess(max_error1, eps)
+
+    def test_bosh3_gradient(self):
+        f, y0, t_points, sol = construct_problem(TEST_DEVICE)
+
+        tuple_f = lambda t, y: (f(t, y[0]), f(t, y[1]))
+
+        for i in range(2):
+            func = lambda y0, t_points: torchdiffeq.odeint(tuple_f, (y0, y0), t_points, method='bosh3')[i]
+            self.assertTrue(torch.autograd.gradcheck(func, (y0, t_points)))
+
     def test_adams(self):
         f, y0, t_points, sol = construct_problem(TEST_DEVICE)
 

--- a/tests/gradient_tests.py
+++ b/tests/gradient_tests.py
@@ -36,6 +36,12 @@ class TestGradient(unittest.TestCase):
         func = lambda y0, t_points: torchdiffeq.odeint(f, y0, t_points, method='dopri5')
         self.assertTrue(torch.autograd.gradcheck(func, (y0, t_points)))
 
+    def test_bosh3(self):
+        f, y0, t_points, _ = construct_problem(TEST_DEVICE)
+
+        func = lambda y0, t_points: torchdiffeq.odeint(f, y0, t_points, method='bosh3')
+        self.assertTrue(torch.autograd.gradcheck(func, (y0, t_points)))
+
     def test_adams(self):
         f, y0, t_points, _ = construct_problem(TEST_DEVICE)
 

--- a/torchdiffeq/_impl/adaptive_heun.py
+++ b/torchdiffeq/_impl/adaptive_heun.py
@@ -120,9 +120,10 @@ class AdaptiveHeunSolver(AdaptiveStepsizeODESolver):
         t_next = t0 + dt + 2 * eps if accept_step else t0
         y_next = y1 if accept_step else y0
         if on_grid and accept_step:
-            # We've just passed a grid point, which is typically used to indicate a discontinuity in f; we should
-            # update f to match the side of the discontinuity we're now on.
-            f1 = self.func(t_next.type_as(y_next[0]), y_next)
+            if eps != 0:
+                # We've just passed a discontinuity in f; we should update f1 to match the side of the discontinuity
+                # we're now on.
+                f1 = self.func(t_next.type_as(y_next[0]), y_next)
             if self.next_grid_index != len(self.grid_points) - 1:
                 self.next_grid_index += 1
         f_next = f1 if accept_step else f0

--- a/torchdiffeq/_impl/adaptive_heun.py
+++ b/torchdiffeq/_impl/adaptive_heun.py
@@ -122,13 +122,13 @@ class AdaptiveHeunSolver(AdaptiveStepsizeODESolver):
         if on_grid and accept_step:
             # We've just passed a grid point, which is typically used to indicate a discontinuity in f; we should
             # update f to match the side of the discontinuity we're now on.
-            f1 = self.func(t_next, y_next)
+            f1 = self.func(t_next.type_as(y_next[0]), y_next)
             if self.next_grid_index != len(self.grid_points) - 1:
                 self.next_grid_index += 1
         f_next = f1 if accept_step else f0
         interp_coeff = _interp_fit_adaptive_heun(y0, y1, k, dt) if accept_step else interp_coeff
         dt_next = _optimal_step_size(
-            dt, mean_sq_error_ratio, safety=self.safety, ifactor=self.ifactor, dfactor=self.dfactor, order=5
+            dt, mean_sq_error_ratio, safety=self.safety, ifactor=self.ifactor, dfactor=self.dfactor, order=2
         )
         rk_state = _RungeKuttaState(y_next, f_next, t0, t_next, dt_next, interp_coeff)
         return rk_state

--- a/torchdiffeq/_impl/adaptive_heun.py
+++ b/torchdiffeq/_impl/adaptive_heun.py
@@ -1,4 +1,5 @@
 # Based on https://github.com/tensorflow/tensorflow/tree/master/tensorflow/contrib/integrate
+import bisect
 import torch
 from .misc import (
     _scaled_dot_product, _convert_to_tensor, _is_finite, _select_initial_step, _handle_unused_kwargs, _is_iterable,
@@ -48,7 +49,7 @@ class AdaptiveHeunSolver(AdaptiveStepsizeODESolver):
 
     def __init__(
         self, func, y0, rtol, atol, first_step=None, safety=0.9, ifactor=10.0, dfactor=0.2, max_num_steps=2**31 - 1,
-        **unused_kwargs
+        grid_points=(), eps=0., **unused_kwargs
     ):
         _handle_unused_kwargs(self, unused_kwargs)
         del unused_kwargs
@@ -62,6 +63,9 @@ class AdaptiveHeunSolver(AdaptiveStepsizeODESolver):
         self.ifactor = _convert_to_tensor(ifactor, dtype=torch.float64, device=y0[0].device)
         self.dfactor = _convert_to_tensor(dfactor, dtype=torch.float64, device=y0[0].device)
         self.max_num_steps = _convert_to_tensor(max_num_steps, dtype=torch.int32, device=y0[0].device)
+        self.grid_points = tuple(_convert_to_tensor(point, dtype=torch.float64, device=y0[0].device)
+                                 for point in grid_points)
+        self.eps = _convert_to_tensor(eps, dtype=torch.float64, device=y0[0].device)
 
     def before_integrate(self, t):
         f0 = self.func(t[0].type_as(self.y0[0]), self.y0)
@@ -70,6 +74,7 @@ class AdaptiveHeunSolver(AdaptiveStepsizeODESolver):
         else:
             first_step = _convert_to_tensor(self.first_step, dtype=t.dtype, device=t.device)
         self.rk_state = _RungeKuttaState(self.y0, f0, t[0], t[0], first_step, interp_coeff=[self.y0] * 5)
+        self.next_grid_index = min(bisect.bisect(self.grid_points, t[0]), len(self.grid_points) - 1)
 
     def advance(self, next_t):
         """Interpolate through the next time point, integrating as necessary."""
@@ -89,6 +94,18 @@ class AdaptiveHeunSolver(AdaptiveStepsizeODESolver):
         assert t0 + dt > t0, 'underflow in dt {}'.format(dt.item())
         for y0_ in y0:
             assert _is_finite(torch.abs(y0_)), 'non-finite values in state `y`: {}'.format(y0_)
+
+        ########################################################
+        #     Make step, respecting prescribed grid points     #
+        ########################################################
+        on_grid = len(self.grid_points) and t0 < self.grid_points[self.next_grid_index] < t0 + dt
+        if on_grid:
+            dt = self.grid_points[self.next_grid_index] - t0
+            eps = min(0.5 * dt, self.eps)
+            dt = dt - eps
+        else:
+            eps = 0
+
         y1, f1, y1_error, k = _runge_kutta_step(self.func, y0, f0, t0, dt, tableau=_ADAPTIVE_HEUN_TABLEAU)
 
         ########################################################
@@ -100,9 +117,15 @@ class AdaptiveHeunSolver(AdaptiveStepsizeODESolver):
         ########################################################
         #                   Update RK State                    #
         ########################################################
+        t_next = t0 + dt + 2 * eps if accept_step else t0
         y_next = y1 if accept_step else y0
+        if on_grid and accept_step:
+            # We've just passed a grid point, which is typically used to indicate a discontinuity in f; we should
+            # update f to match the side of the discontinuity we're now on.
+            f1 = self.func(t_next, y_next)
+            if self.next_grid_index != len(self.grid_points) - 1:
+                self.next_grid_index += 1
         f_next = f1 if accept_step else f0
-        t_next = t0 + dt if accept_step else t0
         interp_coeff = _interp_fit_adaptive_heun(y0, y1, k, dt) if accept_step else interp_coeff
         dt_next = _optimal_step_size(
             dt, mean_sq_error_ratio, safety=self.safety, ifactor=self.ifactor, dfactor=self.dfactor, order=5

--- a/torchdiffeq/_impl/adjoint.py
+++ b/torchdiffeq/_impl/adjoint.py
@@ -30,6 +30,14 @@ class OdeintAdjointMethod(torch.autograd.Function):
         n_tensors = len(ans)
         f_params = tuple(func.parameters())
 
+        try:
+            grid_points = adjoint_options['grid_points']
+        except KeyError:
+            pass
+        else:
+            adjoint_options = adjoint_options.copy()
+            adjoint_options['grid_points'] = grid_points.flip(0)
+
         # TODO: use a nn.Module and call odeint_adjoint to implement higher order derivatives.
         def augmented_dynamics(t, y_aug):
             # Dynamics of the original system augmented with

--- a/torchdiffeq/_impl/adjoint.py
+++ b/torchdiffeq/_impl/adjoint.py
@@ -32,7 +32,7 @@ class OdeintAdjointMethod(torch.autograd.Function):
 
         try:
             grid_points = adjoint_options['grid_points']
-        except KeyError:
+        except (KeyError, TypeError):
             pass
         else:
             adjoint_options = adjoint_options.copy()

--- a/torchdiffeq/_impl/bosh3.py
+++ b/torchdiffeq/_impl/bosh3.py
@@ -106,9 +106,10 @@ class Bosh3Solver(AdaptiveStepsizeODESolver):
         t_next = t0 + dt + 2 * eps if accept_step else t0
         y_next = y1 if accept_step else y0
         if on_grid and accept_step:
-            # We've just passed a grid point, which is typically used to indicate a discontinuity in f; we should
-            # update f to match the side of the discontinuity we're now on.
-            f1 = self.func(t_next.type_as(y_next[0]), y_next)
+            if eps != 0:
+                # We've just passed a discontinuity in f; we should update f1 to match the side of the discontinuity
+                # we're now on.
+                f1 = self.func(t_next.type_as(y_next[0]), y_next)
             if self.next_grid_index != len(self.grid_points) - 1:
                 self.next_grid_index += 1
         f_next = f1 if accept_step else f0

--- a/torchdiffeq/_impl/bosh3.py
+++ b/torchdiffeq/_impl/bosh3.py
@@ -108,7 +108,7 @@ class Bosh3Solver(AdaptiveStepsizeODESolver):
         if on_grid and accept_step:
             # We've just passed a grid point, which is typically used to indicate a discontinuity in f; we should
             # update f to match the side of the discontinuity we're now on.
-            f1 = self.func(t_next, y_next)
+            f1 = self.func(t_next.type_as(y_next[0]), y_next)
             if self.next_grid_index != len(self.grid_points) - 1:
                 self.next_grid_index += 1
         f_next = f1 if accept_step else f0

--- a/torchdiffeq/_impl/bosh3.py
+++ b/torchdiffeq/_impl/bosh3.py
@@ -1,3 +1,4 @@
+import bisect
 import torch
 from .misc import (
     _scaled_dot_product, _convert_to_tensor, _is_finite, _select_initial_step, _handle_unused_kwargs, _is_iterable,
@@ -30,12 +31,11 @@ def _interp_fit_bosh3(y0, y1, k, dt):
     return _interp_fit(y0, y1, y_mid, f0, f1, dt)
 
 
-
 class Bosh3Solver(AdaptiveStepsizeODESolver):
 
     def __init__(
         self, func, y0, rtol, atol, first_step=None, safety=0.9, ifactor=10.0, dfactor=0.2, max_num_steps=2**31 - 1,
-        **unused_kwargs
+        grid_points=(), eps=0., **unused_kwargs
     ):
         _handle_unused_kwargs(self, unused_kwargs)
         del unused_kwargs
@@ -49,6 +49,9 @@ class Bosh3Solver(AdaptiveStepsizeODESolver):
         self.ifactor = _convert_to_tensor(ifactor, dtype=torch.float64, device=y0[0].device)
         self.dfactor = _convert_to_tensor(dfactor, dtype=torch.float64, device=y0[0].device)
         self.max_num_steps = _convert_to_tensor(max_num_steps, dtype=torch.int32, device=y0[0].device)
+        self.grid_points = tuple(_convert_to_tensor(point, dtype=torch.float64, device=y0[0].device)
+                                 for point in grid_points)
+        self.eps = _convert_to_tensor(eps, dtype=torch.float64, device=y0[0].device)
 
     def before_integrate(self, t):
         f0 = self.func(t[0].type_as(self.y0[0]), self.y0)
@@ -57,6 +60,7 @@ class Bosh3Solver(AdaptiveStepsizeODESolver):
         else:
             first_step = _convert_to_tensor(self.first_step, dtype=t.dtype, device=t.device)
         self.rk_state = _RungeKuttaState(self.y0, f0, t[0], t[0], first_step, interp_coeff=[self.y0] * 5)
+        self.next_grid_index = min(bisect.bisect(self.grid_points, t[0]), len(self.grid_points) - 1)
 
     def advance(self, next_t):
         """Interpolate through the next time point, integrating as necessary."""
@@ -76,6 +80,18 @@ class Bosh3Solver(AdaptiveStepsizeODESolver):
         assert t0 + dt > t0, 'underflow in dt {}'.format(dt.item())
         for y0_ in y0:
             assert _is_finite(torch.abs(y0_)), 'non-finite values in state `y`: {}'.format(y0_)
+
+        ########################################################
+        #     Make step, respecting prescribed grid points     #
+        ########################################################
+        on_grid = len(self.grid_points) and t0 < self.grid_points[self.next_grid_index] < t0 + dt
+        if on_grid:
+            dt = self.grid_points[self.next_grid_index] - t0
+            eps = min(0.5 * dt, self.eps)
+            dt = dt - eps
+        else:
+            eps = 0
+
         y1, f1, y1_error, k = _runge_kutta_step(self.func, y0, f0, t0, dt, tableau=_BOGACKI_SHAMPINE_TABLEAU)
 
         ########################################################
@@ -87,9 +103,15 @@ class Bosh3Solver(AdaptiveStepsizeODESolver):
         ########################################################
         #                   Update RK State                    #
         ########################################################
+        t_next = t0 + dt + 2 * eps if accept_step else t0
         y_next = y1 if accept_step else y0
+        if on_grid and accept_step:
+            # We've just passed a grid point, which is typically used to indicate a discontinuity in f; we should
+            # update f to match the side of the discontinuity we're now on.
+            f1 = self.func(t_next, y_next)
+            if self.next_grid_index != len(self.grid_points) - 1:
+                self.next_grid_index += 1
         f_next = f1 if accept_step else f0
-        t_next = t0 + dt if accept_step else t0
         interp_coeff = _interp_fit_bosh3(y0, y1, k, dt) if accept_step else interp_coeff
         dt_next = _optimal_step_size(
             dt, mean_sq_error_ratio, safety=self.safety, ifactor=self.ifactor, dfactor=self.dfactor, order=3

--- a/torchdiffeq/_impl/dopri5.py
+++ b/torchdiffeq/_impl/dopri5.py
@@ -132,9 +132,10 @@ class Dopri5Solver(AdaptiveStepsizeODESolver):
         t_next = t0 + dt + 2 * eps if accept_step else t0
         y_next = y1 if accept_step else y0
         if on_grid and accept_step:
-            # We've just passed a grid point, which is typically used to indicate a discontinuity in f; we should
-            # update f to match the side of the discontinuity we're now on.
-            f1 = self.func(t_next.type_as(y_next[0]), y_next)
+            if eps != 0:
+                # We've just passed a discontinuity in f; we should update f1 to match the side of the discontinuity
+                # we're now on.
+                f1 = self.func(t_next.type_as(y_next[0]), y_next)
             if self.next_grid_index != len(self.grid_points) - 1:
                 self.next_grid_index += 1
         f_next = f1 if accept_step else f0

--- a/torchdiffeq/_impl/dopri5.py
+++ b/torchdiffeq/_impl/dopri5.py
@@ -1,4 +1,5 @@
 # Based on https://github.com/tensorflow/tensorflow/tree/master/tensorflow/contrib/integrate
+import bisect
 import torch
 from .misc import (
     _scaled_dot_product, _convert_to_tensor, _is_finite, _select_initial_step, _handle_unused_kwargs, _is_iterable,
@@ -59,7 +60,7 @@ class Dopri5Solver(AdaptiveStepsizeODESolver):
 
     def __init__(
         self, func, y0, rtol, atol, first_step=None, safety=0.9, ifactor=10.0, dfactor=0.2, max_num_steps=2**31 - 1,
-        **unused_kwargs
+        grid_points=(), eps=0., **unused_kwargs
     ):
         _handle_unused_kwargs(self, unused_kwargs)
         del unused_kwargs
@@ -73,6 +74,9 @@ class Dopri5Solver(AdaptiveStepsizeODESolver):
         self.ifactor = _convert_to_tensor(ifactor, dtype=torch.float64, device=y0[0].device)
         self.dfactor = _convert_to_tensor(dfactor, dtype=torch.float64, device=y0[0].device)
         self.max_num_steps = _convert_to_tensor(max_num_steps, dtype=torch.int32, device=y0[0].device)
+        self.grid_points = tuple(_convert_to_tensor(point, dtype=torch.float64, device=y0[0].device)
+                                 for point in grid_points)
+        self.eps = _convert_to_tensor(eps, dtype=torch.float64, device=y0[0].device)
 
     def before_integrate(self, t):
         f0 = self.func(t[0].type_as(self.y0[0]), self.y0)
@@ -81,6 +85,7 @@ class Dopri5Solver(AdaptiveStepsizeODESolver):
         else:
             first_step = _convert_to_tensor(self.first_step, dtype=t.dtype, device=t.device)
         self.rk_state = _RungeKuttaState(self.y0, f0, t[0], t[0], first_step, interp_coeff=[self.y0] * 5)
+        self.next_grid_index = min(bisect.bisect(self.grid_points, t[0]), len(self.grid_points) - 1)
 
     def advance(self, next_t):
         """Interpolate through the next time point, integrating as necessary."""
@@ -94,12 +99,25 @@ class Dopri5Solver(AdaptiveStepsizeODESolver):
     def _adaptive_dopri5_step(self, rk_state):
         """Take an adaptive Runge-Kutta step to integrate the ODE."""
         y0, f0, _, t0, dt, interp_coeff = rk_state
+
         ########################################################
         #                      Assertions                      #
         ########################################################
         assert t0 + dt > t0, 'underflow in dt {}'.format(dt.item())
         for y0_ in y0:
             assert _is_finite(torch.abs(y0_)), 'non-finite values in state `y`: {}'.format(y0_)
+
+        ########################################################
+        #     Make step, respecting prescribed grid points     #
+        ########################################################
+        on_grid = len(self.grid_points) and t0 < self.grid_points[self.next_grid_index] < t0 + dt
+        if on_grid:
+            dt = self.grid_points[self.next_grid_index] - t0
+            eps = min(0.5 * dt, self.eps)
+            dt = dt - eps
+        else:
+            eps = 0
+
         y1, f1, y1_error, k = _runge_kutta_step(self.func, y0, f0, t0, dt, tableau=_DORMAND_PRINCE_SHAMPINE_TABLEAU)
 
         ########################################################
@@ -111,9 +129,15 @@ class Dopri5Solver(AdaptiveStepsizeODESolver):
         ########################################################
         #                   Update RK State                    #
         ########################################################
+        t_next = t0 + dt + 2 * eps if accept_step else t0
         y_next = y1 if accept_step else y0
+        if on_grid and accept_step:
+            # We've just passed a grid point, which is typically used to indicate a discontinuity in f; we should
+            # update f to match the side of the discontinuity we're now on.
+            f1 = self.func(t_next, y_next)
+            if self.next_grid_index != len(self.grid_points) - 1:
+                self.next_grid_index += 1
         f_next = f1 if accept_step else f0
-        t_next = t0 + dt if accept_step else t0
         interp_coeff = _interp_fit_dopri5(y0, y1, k, dt) if accept_step else interp_coeff
         dt_next = _optimal_step_size(
             dt, mean_sq_error_ratio, safety=self.safety, ifactor=self.ifactor, dfactor=self.dfactor, order=5

--- a/torchdiffeq/_impl/dopri5.py
+++ b/torchdiffeq/_impl/dopri5.py
@@ -134,7 +134,7 @@ class Dopri5Solver(AdaptiveStepsizeODESolver):
         if on_grid and accept_step:
             # We've just passed a grid point, which is typically used to indicate a discontinuity in f; we should
             # update f to match the side of the discontinuity we're now on.
-            f1 = self.func(t_next, y_next)
+            f1 = self.func(t_next.type_as(y_next[0]), y_next)
             if self.next_grid_index != len(self.grid_points) - 1:
                 self.next_grid_index += 1
         f_next = f1 if accept_step else f0

--- a/torchdiffeq/_impl/dopri8.py
+++ b/torchdiffeq/_impl/dopri8.py
@@ -114,7 +114,7 @@ class Dopri8Solver(AdaptiveStepsizeODESolver):
         if on_grid and accept_step:
             # We've just passed a grid point, which is typically used to indicate a discontinuity in f; we should
             # update f to match the side of the discontinuity we're now on.
-            f1 = self.func(t_next, y_next)
+            f1 = self.func(t_next.type_as(y_next[0]), y_next)
             if self.next_grid_index != len(self.grid_points) - 1:
                 self.next_grid_index += 1
         f_next = f1 if accept_step else f0

--- a/torchdiffeq/_impl/dopri8.py
+++ b/torchdiffeq/_impl/dopri8.py
@@ -1,3 +1,4 @@
+import bisect
 import torch
 from .misc import (
     _scaled_dot_product, _convert_to_tensor, _is_finite, _select_initial_step, _handle_unused_kwargs, _is_iterable,
@@ -40,7 +41,7 @@ class Dopri8Solver(AdaptiveStepsizeODESolver):
 
     def __init__(
         self, func, y0, rtol, atol, first_step=None, safety=0.9, ifactor=10.0, dfactor=0.2, max_num_steps=2**31 - 1,
-        **unused_kwargs
+        grid_points=(), eps=0., **unused_kwargs
     ):
         _handle_unused_kwargs(self, unused_kwargs)
         del unused_kwargs
@@ -54,6 +55,9 @@ class Dopri8Solver(AdaptiveStepsizeODESolver):
         self.ifactor = _convert_to_tensor(ifactor, dtype=torch.float64, device=y0[0].device)
         self.dfactor = _convert_to_tensor(dfactor, dtype=torch.float64, device=y0[0].device)
         self.max_num_steps = _convert_to_tensor(max_num_steps, dtype=torch.int32, device=y0[0].device)
+        self.grid_points = tuple(_convert_to_tensor(point, dtype=torch.float64, device=y0[0].device)
+                                 for point in grid_points)
+        self.eps = _convert_to_tensor(eps, dtype=torch.float64, device=y0[0].device)
 
     def before_integrate(self, t):
         f0 = self.func(t[0].type_as(self.y0[0]), self.y0)
@@ -62,6 +66,7 @@ class Dopri8Solver(AdaptiveStepsizeODESolver):
         else:
             first_step = _convert_to_tensor(self.first_step, dtype=t.dtype, device=t.device)
         self.rk_state = _RungeKuttaState(self.y0, f0, t[0], t[0], first_step, interp_coeff=[self.y0] * 5)
+        self.next_grid_index = min(bisect.bisect(self.grid_points, t[0]), len(self.grid_points) - 1)
 
     def advance(self, next_t):
         """Interpolate through the next time point, integrating as necessary."""
@@ -81,6 +86,18 @@ class Dopri8Solver(AdaptiveStepsizeODESolver):
         assert t0 + dt > t0, 'underflow in dt {}'.format(dt.item())
         for y0_ in y0:
             assert _is_finite(torch.abs(y0_)), 'non-finite values in state `y`: {}'.format(y0_)
+
+        ########################################################
+        #     Make step, respecting prescribed grid points     #
+        ########################################################
+        on_grid = len(self.grid_points) and t0 < self.grid_points[self.next_grid_index] < t0 + dt
+        if on_grid:
+            dt = self.grid_points[self.next_grid_index] - t0
+            eps = min(0.5 * dt, self.eps)
+            dt = dt - eps
+        else:
+            eps = 0
+
         y1, f1, y1_error, k = _runge_kutta_step(self.func, y0, f0, t0, dt, tableau=_DOPRI8_TABLEAU)
 
         ########################################################
@@ -92,9 +109,15 @@ class Dopri8Solver(AdaptiveStepsizeODESolver):
         ########################################################
         #                   Update RK State                    #
         ########################################################
+        t_next = t0 + dt + 2 * eps if accept_step else t0
         y_next = y1 if accept_step else y0
+        if on_grid and accept_step:
+            # We've just passed a grid point, which is typically used to indicate a discontinuity in f; we should
+            # update f to match the side of the discontinuity we're now on.
+            f1 = self.func(t_next, y_next)
+            if self.next_grid_index != len(self.grid_points) - 1:
+                self.next_grid_index += 1
         f_next = f1 if accept_step else f0
-        t_next = t0 + dt if accept_step else t0
         interp_coeff = _interp_fit_dopri8(y0, y1, k, dt) if accept_step else interp_coeff
         dt_next = _optimal_step_size(
             dt, mean_sq_error_ratio, safety=self.safety, ifactor=self.ifactor, dfactor=self.dfactor, order=8

--- a/torchdiffeq/_impl/dopri8.py
+++ b/torchdiffeq/_impl/dopri8.py
@@ -112,9 +112,10 @@ class Dopri8Solver(AdaptiveStepsizeODESolver):
         t_next = t0 + dt + 2 * eps if accept_step else t0
         y_next = y1 if accept_step else y0
         if on_grid and accept_step:
-            # We've just passed a grid point, which is typically used to indicate a discontinuity in f; we should
-            # update f to match the side of the discontinuity we're now on.
-            f1 = self.func(t_next.type_as(y_next[0]), y_next)
+            if eps != 0:
+                # We've just passed a discontinuity in f; we should update f1 to match the side of the discontinuity
+                # we're now on.
+                f1 = self.func(t_next.type_as(y_next[0]), y_next)
             if self.next_grid_index != len(self.grid_points) - 1:
                 self.next_grid_index += 1
         f_next = f1 if accept_step else f0

--- a/torchdiffeq/_impl/misc.py
+++ b/torchdiffeq/_impl/misc.py
@@ -56,8 +56,12 @@ def _decreasing(t):
     return (t[1:] < t[:-1]).all()
 
 
-def _assert_increasing(t):
-    assert (t[1:] > t[:-1]).all(), 't must be strictly increasing or decreasing'
+def _assert_one_dimensional(name, t):
+    assert t.ndimension() == 1, "{} must be one dimensional".format(name)
+
+
+def _assert_increasing(name, t):
+    assert (t[1:] > t[:-1]).all(), '{} must be strictly increasing or decreasing'.format(name)
 
 
 def _is_iterable(inputs):
@@ -192,6 +196,18 @@ def _check_inputs(func, y0, t, options):
         else:
             options = options.copy()
             options['grid_points'] = -grid_points
+
+    assert torch.is_tensor(t), 't must be a torch.Tensor'
+    _assert_one_dimensional('t', t)
+    _assert_increasing('t', t)
+    try:
+        grid_points = options['grid_points']
+    except KeyError:
+        pass
+    else:
+        assert torch.is_tensor(grid_points), 'grid_points must be a torch.Tensor'
+        _assert_one_dimensional('grid_points', grid_points)
+        _assert_increasing('grid_points', grid_points)
 
     for y0_ in y0:
         if not torch.is_floating_point(y0_):

--- a/torchdiffeq/_impl/misc.py
+++ b/torchdiffeq/_impl/misc.py
@@ -170,7 +170,7 @@ def _optimal_step_size(last_step, mean_error_ratio, safety=0.9, ifactor=10.0, df
     return last_step / factor
 
 
-def _check_inputs(func, y0, t):
+def _check_inputs(func, y0, t, options):
     tensor_input = False
     if torch.is_tensor(y0):
         tensor_input = True
@@ -185,6 +185,13 @@ def _check_inputs(func, y0, t):
         t = -t
         _base_reverse_func = func
         func = lambda t, y: tuple(-f_ for f_ in _base_reverse_func(-t, y))
+        try:
+            grid_points = options['grid_points']
+        except KeyError:
+            pass
+        else:
+            options = options.copy()
+            options['grid_points'] = -grid_points
 
     for y0_ in y0:
         if not torch.is_floating_point(y0_):
@@ -192,4 +199,4 @@ def _check_inputs(func, y0, t):
     if not torch.is_floating_point(t):
         raise TypeError('`t` must be a floating point Tensor but is a {}'.format(t.type()))
 
-    return tensor_input, func, y0, t
+    return tensor_input, func, y0, t, options

--- a/torchdiffeq/_impl/odeint.py
+++ b/torchdiffeq/_impl/odeint.py
@@ -61,12 +61,12 @@ def odeint(func, y0, t, rtol=1e-7, atol=1e-9, method=None, options=None):
         ValueError: if an invalid `method` is provided.
     """
 
-    tensor_input, func, y0, t = _check_inputs(func, y0, t)
-
     if options is None:
         options = {}
     elif method is None:
         raise ValueError('cannot supply `options` without specifying `method`')
+
+    tensor_input, func, y0, t, options = _check_inputs(func, y0, t, options)
         
     if method is None:
         method = 'dopri5'

--- a/torchdiffeq/_impl/solvers.py
+++ b/torchdiffeq/_impl/solvers.py
@@ -23,7 +23,6 @@ class AdaptiveStepsizeODESolver(object):
         raise NotImplementedError
 
     def integrate(self, t):
-        _assert_increasing(t)
         solution = [self.y0]
         t = t.to(self.y0[0].device, torch.float64)
         self.before_integrate(t)
@@ -82,7 +81,6 @@ class FixedGridODESolver(object):
         pass
 
     def integrate(self, t):
-        _assert_increasing(t)
         t = t.type_as(self.y0[0])
         time_grid = self.grid_constructor(self.func, self.y0, t)
         assert time_grid[0] == t[0] and time_grid[-1] == t[-1]

--- a/torchdiffeq/_impl/tsit5.py
+++ b/torchdiffeq/_impl/tsit5.py
@@ -1,3 +1,4 @@
+import bisect
 import torch
 from .misc import _scaled_dot_product, _convert_to_tensor, _is_finite, _select_initial_step, _handle_unused_kwargs
 from .solvers import AdaptiveStepsizeODESolver
@@ -67,7 +68,7 @@ class Tsit5Solver(AdaptiveStepsizeODESolver):
 
     def __init__(
         self, func, y0, rtol, atol, first_step=None, safety=0.9, ifactor=10.0, dfactor=0.2, max_num_steps=2**31 - 1,
-        **unused_kwargs
+        grid_points=(), eps=0., **unused_kwargs
     ):
         _handle_unused_kwargs(self, unused_kwargs)
         del unused_kwargs
@@ -81,6 +82,9 @@ class Tsit5Solver(AdaptiveStepsizeODESolver):
         self.ifactor = _convert_to_tensor(ifactor, dtype=torch.float64, device=y0[0].device)
         self.dfactor = _convert_to_tensor(dfactor, dtype=torch.float64, device=y0[0].device)
         self.max_num_steps = _convert_to_tensor(max_num_steps, dtype=torch.int32, device=y0[0].device)
+        self.grid_points = tuple(_convert_to_tensor(point, dtype=torch.float64, device=y0[0].device)
+                                 for point in grid_points)
+        self.eps = _convert_to_tensor(eps, dtype=torch.float64, device=y0[0].device)
 
     def before_integrate(self, t):
         if self.first_step is None:
@@ -92,6 +96,7 @@ class Tsit5Solver(AdaptiveStepsizeODESolver):
             self.func(t[0].type_as(self.y0[0]), self.y0), t[0], t[0], first_step,
             tuple(map(lambda x: [x] * 7, self.y0))
         )
+        self.next_grid_index = min(bisect.bisect(self.grid_points, t[0]), len(self.grid_points) - 1)
 
     def advance(self, next_t):
         """Interpolate through the next time point, integrating as necessary."""
@@ -111,6 +116,18 @@ class Tsit5Solver(AdaptiveStepsizeODESolver):
         assert t0 + dt > t0, 'underflow in dt {}'.format(dt.item())
         for y0_ in y0:
             assert _is_finite(torch.abs(y0_)), 'non-finite values in state `y`: {}'.format(y0_)
+
+        ########################################################
+        #     Make step, respecting prescribed grid points     #
+        ########################################################
+        on_grid = len(self.grid_points) and t0 < self.grid_points[self.next_grid_index] < t0 + dt
+        if on_grid:
+            dt = self.grid_points[self.next_grid_index] - t0
+            eps = min(0.5 * dt, self.eps)
+            dt = dt - eps
+        else:
+            eps = 0
+
         y1, f1, y1_error, k = _runge_kutta_step(self.func, y0, f0, t0, dt, tableau=_TSITOURAS_TABLEAU)
 
         ########################################################
@@ -130,9 +147,15 @@ class Tsit5Solver(AdaptiveStepsizeODESolver):
         ########################################################
         #                   Update RK State                    #
         ########################################################
+        t_next = t0 + dt + 2 * eps if accept_step else t0
         y_next = y1 if accept_step else y0
+        if on_grid and accept_step:
+            # We've just passed a grid point, which is typically used to indicate a discontinuity in f; we should
+            # update f to match the side of the discontinuity we're now on.
+            f1 = self.func(t_next, y_next)
+            if self.next_grid_index != len(self.grid_points) - 1:
+                self.next_grid_index += 1
         f_next = f1 if accept_step else f0
-        t_next = t0 + dt if accept_step else t0
         dt_next = _optimal_step_size(dt, mean_error_ratio, self.safety, self.ifactor, self.dfactor)
         k_next = k if accept_step else self.rk_state.interp_coeff
         rk_state = _RungeKuttaState(y_next, f_next, t0, t_next, dt_next, k_next)

--- a/torchdiffeq/_impl/tsit5.py
+++ b/torchdiffeq/_impl/tsit5.py
@@ -150,9 +150,10 @@ class Tsit5Solver(AdaptiveStepsizeODESolver):
         t_next = t0 + dt + 2 * eps if accept_step else t0
         y_next = y1 if accept_step else y0
         if on_grid and accept_step:
-            # We've just passed a grid point, which is typically used to indicate a discontinuity in f; we should
-            # update f to match the side of the discontinuity we're now on.
-            f1 = self.func(t_next, y_next)
+            if eps != 0:
+                # We've just passed a discontinuity in f; we should update f1 to match the side of the discontinuity
+                # we're now on.
+                f1 = self.func(t_next.type_as(y_next[0]), y_next)
             if self.next_grid_index != len(self.grid_points) - 1:
                 self.next_grid_index += 1
         f_next = f1 if accept_step else f0


### PR DESCRIPTION
Following on from our discussion in #109 - added functionality for respecting discontinuities and derivative discontinuities to adaptive solvers.

They take new options `grid_points` and `eps`; the former specifies where the discontinuities are; the latter additionally specifies a small perturbation either side of them when the vector field itself is discontinuous. (Analogous to the `eps` argument already present on the fixed solvers.)

Example usage:
```
t = torch.linspace(0, 1, 5)
odeint(..., t=t[[0, -1]], method='dopri5', options=dict(grid_points=t, eps=1e-5))
```
for a function with discontinuities at `1/4`, `1/2`, `3/4`. (Including the start point `0` in `grid_points` doesn't affect anything. Including the end point `1` should actually always improve things slightly regardless of the presence of discontinuities.)

I observe this giving an order of magnitude improvement in the NFE/speed on some discontinuous problems I'm trying. All tests pass (except the 2 that never pass even before the change).

---

Whilst I'm here, a couple unrelated questions:

- What's the status of the less-loved `bosh3`, `adaptive_heun`, `tsit5` solvers? They don't appear in the documentation, but both of the former two seem to work when I try them. (I think something might be wrong with `tsit5` - I didn't dig into it but the solve took longer than I cared to wait.)

- How would you feel about adding an `adjoint_buffers` argument to `odeint_adjoint`, which if passed as `True` will additionally compute adjoints wrt `(buffer for buffer in func.buffers() if buffer.requires_grad)`? I know this sort of idea has been discussed in previous issues before (#104, #94), and can be handled by faffing around with including it in the state; this would just be a QOL improvement.