### PR TITLE
Implementation of 4th Order Symplectic Integrator with Adjoint Method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.egg
 *__pycache__*
 .vscode
+*.swp

--- a/tests/gradient_tests.py
+++ b/tests/gradient_tests.py
@@ -2,7 +2,8 @@ import unittest
 import torch
 import torchdiffeq
 
-from problems import construct_problem, PROBLEMS, DEVICES, METHODS
+from problems import construct_problem, PROBLEMS, DEVICES, METHODS, \
+                     FIXED_SYMPLECTIC_METHODS
 
 
 def max_abs(tensor):
@@ -15,7 +16,10 @@ class TestGradient(unittest.TestCase):
             for method in METHODS:
 
                 with self.subTest(device=device, method=method):
-                    f, y0, t_points, _ = construct_problem(device=device)
+                    if method in FIXED_SYMPLECTIC_METHODS:
+                        f, y0, t_points, _ = construct_problem(device=device,ode='constant_symplectic')
+                    else:
+                        f, y0, t_points, _ = construct_problem(device=device)
                     func = lambda y0, t_points: torchdiffeq.odeint(f, y0, t_points, method=method)
                     self.assertTrue(torch.autograd.gradcheck(func, (y0, t_points)))
 
@@ -32,15 +36,17 @@ class TestGradient(unittest.TestCase):
                         eps = 1e-5
                     elif ode == 'sine':
                         eps = 5e-3
+                    elif ode in ['harmonic','constant_symplectic']:
+                        eps = 1e-5
                     else:
                         raise RuntimeError
 
                     with self.subTest(device=device, ode=ode, t_grad=t_grad):
+                        torch.manual_seed(1234)
                         f, y0, t_points, _ = construct_problem(device=device, ode=ode)
                         t_points.requires_grad_(t_grad)
 
                         ys = torchdiffeq.odeint(f, y0, t_points, rtol=1e-9, atol=1e-12)
-                        torch.manual_seed(0)
                         gradys = torch.rand_like(ys)
                         ys.backward(gradys)
 
@@ -116,6 +122,52 @@ class TestCompareAdjointGradient(unittest.TestCase):
                         if t_grad:
                             self.assertLess(max_abs(t_points.grad - adj_t_grad), eps[1])
                         self.assertLess(max_abs(func.A.grad - adj_A_grad), eps[2])
+
+
+class TestCompareAdjointGradientforSymplectic(unittest.TestCase):
+    def test_adjoint_sympelctic(self):
+
+        for device in DEVICES:
+            for ode in ['harmonic','constant_symplectic']:
+                eps = 3*1e-4
+                dt = 0.01
+                for t_grad in (True,False):
+                    torch.manual_seed(1234)
+                    with self.subTest(device=device, ode=ode, t_grad=t_grad):
+                        f, y0, t_points, _ = construct_problem(device=device, ode=ode)
+                        t_points.requires_grad_(t_grad)
+
+                        ys = torchdiffeq.odeint(f, y0, t_points, method='dopri5')
+                        gradys = torch.rand_like(ys)
+                        ys.backward(gradys)
+
+                        reg_y0_grad = y0.grad.clone()
+                        reg_t_grad = t_points.grad.clone() if t_grad else None
+                        reg_params_grads = []
+                        for param in f.parameters():
+                            reg_params_grads.append(param.grad.clone())
+
+                        y0.grad.zero_()
+                        if t_grad:
+                            t_points.grad.zero_()
+                        for param in f.parameters():
+                            param.grad.zero_()
+                        ys = torchdiffeq.odeint_adjoint(f, y0, t_points, 
+                                                     method='yoshida4th',
+                                                     options={'step_size':dt})
+                        ys.backward(gradys)
+
+                        adj_y0_grad = y0.grad
+                        adj_t_grad = t_points.grad if t_grad else None
+                        adj_params_grads = []
+                        for param in f.parameters():
+                            adj_params_grads.append(param.grad)
+
+                        self.assertLess(max_abs(reg_y0_grad - adj_y0_grad), eps)
+                        if t_grad:
+                            self.assertLess(max_abs(reg_t_grad - adj_t_grad), eps)
+                        for reg_grad, adj_grad in zip(reg_params_grads, adj_params_grads):
+                            self.assertLess(max_abs(reg_grad - adj_grad), eps)
 
 
 if __name__ == '__main__':

--- a/tests/odeint_tests.py
+++ b/tests/odeint_tests.py
@@ -2,7 +2,10 @@ import unittest
 import torch
 import torchdiffeq
 
-from problems import construct_problem, PROBLEMS, DTYPES, DEVICES, METHODS, ADAPTIVE_METHODS
+from problems import construct_problem, \
+                     PROBLEMS, DTYPES, DEVICES, \
+                     METHODS, ADAPTIVE_METHODS, \
+                     FIXED_SYMPLECTIC_METHODS
 
 
 def rel_error(true, estimate):
@@ -11,6 +14,7 @@ def rel_error(true, estimate):
 
 class TestSolverError(unittest.TestCase):
     def test_odeint(self):
+        torch.manual_seed(42)
         for reverse in (False, True):
             for dtype in DTYPES:
                 for device in DEVICES:
@@ -18,49 +22,68 @@ class TestSolverError(unittest.TestCase):
                         if dtype == torch.float32 and method == 'dopri8':
                             continue
                         kwargs = dict(rtol=1e-12, atol=1e-14) if method == 'dopri8' else dict()
-                        problems = PROBLEMS if method in ADAPTIVE_METHODS else ('constant',)
+                        if method in ADAPTIVE_METHODS:
+                            problems = PROBLEMS
+                        elif method in FIXED_SYMPLECTIC_METHODS:
+                            problems = ('harmonic','constant_symplectic',)
+                            kwargs = dict(options={'step_size':0.1})
+                        else:
+                            problems = ('constant',)
                         for ode in problems:
                             if method == 'adaptive_heun':
                                 eps = 4e-3
                             elif method == 'bosh3':
                                 eps = 3e-3
-                            elif ode == 'linear':
+                                if ode == 'constant_symplectic':
+                                    continue
+                            elif ode in ['linear','harmonic']:
                                 eps = 2e-3
                             else:
                                 eps = 1e-4
 
-                            with self.subTest(reverse=reverse, dtype=dtype, device=device, ode=ode, method=method):
+                            with self.subTest(reverse=reverse, dtype=dtype, 
+                                            device=device, ode=ode, method=method):
                                 f, y0, t_points, sol = construct_problem(dtype=dtype, device=device, ode=ode,
                                                                          reverse=reverse)
                                 y = torchdiffeq.odeint(f, y0, t_points, method=method, **kwargs)
                                 self.assertLess(rel_error(sol, y), eps)
-                
+
     def test_adjoint(self):
+        torch.manual_seed(42)
         for reverse in (False, True):
             for dtype in DTYPES:
                 for device in DEVICES:
                     for ode in PROBLEMS:
-                        if ode == 'linear':
+                        if ode in ['linear','harmonic']:
                             eps = 2e-3
                         else:
                             eps = 1e-4
-
                         with self.subTest(reverse=reverse, dtype=dtype, device=device, ode=ode):
                             f, y0, t_points, sol = construct_problem(dtype=dtype, device=device, ode=ode,
                                                                      reverse=reverse)
-                            y = torchdiffeq.odeint_adjoint(f, y0, t_points)
+                            if ode in ['harmonic','constant_symplectic']:
+                                y = torchdiffeq.odeint_adjoint(f, y0, t_points,
+                                                               method='yoshida4th',
+                                                               options={'step_size':0.1})
+                            else:
+                                y = torchdiffeq.odeint_adjoint(f, y0, t_points)
                             self.assertLess(rel_error(sol, y), eps)
 
 
 class TestNoIntegration(unittest.TestCase):
     def test_odeint(self):
+        torch.manual_seed(42)
         for reverse in (False, True):
             for dtype in DTYPES:
                 for device in DEVICES:
                     for method in METHODS:
-                        for ode in PROBLEMS:
-
-                            with self.subTest(reverse=reverse, dtype=dtype, device=device, ode=ode, method=method):
+                        if method in FIXED_SYMPLECTIC_METHODS:
+                            problems = ('harmonic',)
+                        else:
+                            problems = PROBLEMS
+                        for ode in problems:
+                            with self.subTest(reverse=reverse, dtype=dtype, 
+                                        device=device, ode=ode, method=method):
                                 f, y0, t_points, sol = construct_problem(dtype=dtype, device=device, ode=ode,
                                                                          reverse=reverse)
                                 y = torchdiffeq.odeint(f, y0, t_points[0:1], method=method)

--- a/torchdiffeq/_impl/adjoint.py
+++ b/torchdiffeq/_impl/adjoint.py
@@ -40,6 +40,7 @@ class OdeintAdjointMethod(torch.autograd.Function):
             t, y, *adjoint_params = ctx.saved_tensors
             adjoint_params = tuple(adjoint_params)
 
+
             ##################################
             #     Set up adjoint_options     #
             ##################################
@@ -174,7 +175,7 @@ def odeint_adjoint(func, y0, t, rtol=1e-7, atol=1e-9, method=None, options=None,
     if adjoint_options is None:
         adjoint_options = {k: v for k, v in options.items() if k != "norm"} if options is not None else {}
     if adjoint_params is None:
-        adjoint_params = tuple([param.reshape(-1) for param in func.parameters()])
+        adjoint_params = tuple(func.parameters())
     else:
         adjoint_params = tuple(adjoint_params)  # in case adjoint_params is a generator.
 

--- a/torchdiffeq/_impl/adjoint.py
+++ b/torchdiffeq/_impl/adjoint.py
@@ -10,8 +10,9 @@ from .misc import _check_inputs, _flat_to_shape, _rms_norm, \
 class OdeintAdjointMethod(torch.autograd.Function):
 
     @staticmethod
-    def forward(ctx, shapes, func, y0, t, rtol, atol, method, options, adjoint_rtol, adjoint_atol, adjoint_method,
-                adjoint_options, t_requires_grad, *adjoint_params):
+    def forward(ctx, shapes, func, y0, t, rtol, atol, method, options, 
+                adjoint_rtol, adjoint_atol, adjoint_method, adjoint_options, 
+                t_requires_grad, *adjoint_params):
 
         ctx.shapes = shapes
         ctx.func = func
@@ -22,7 +23,8 @@ class OdeintAdjointMethod(torch.autograd.Function):
         ctx.t_requires_grad = t_requires_grad
 
         with torch.no_grad():
-            y = odeint(func, y0, t, rtol=rtol, atol=atol, method=method, options=options)
+            y = odeint(func, y0, t, rtol=rtol, atol=atol, 
+                                        method=method, options=options)
         ctx.save_for_backward(t, y, *adjoint_params)
         return y
 
@@ -50,8 +52,10 @@ class OdeintAdjointMethod(torch.autograd.Function):
             else:
                 adjoint_options = adjoint_options.copy()
 
-            # We assume that any grid points are given to us ordered in the same direction as for the forward pass (for
-            # compatibility with setting adjoint_options = options), so we need to flip them around here.
+            # We assume that any grid points are given to us ordered 
+            # in the same direction as for the forward pass (for
+            # compatibility with setting adjoint_options = options), 
+            # so we need to flip them around here.
             try:
                 grid_points = adjoint_options['grid_points']
             except KeyError:
@@ -59,15 +63,21 @@ class OdeintAdjointMethod(torch.autograd.Function):
             else:
                 adjoint_options['grid_points'] = grid_points.flip(0)
 
-            # Backward compatibility: by default use a mixed L-infinity/RMS norm over the input, where we treat t, each
-            # element of y, and each element of adj_y separately over the Linf, but consider all the parameters
+            # Backward compatibility: by default use a mixed 
+            # L-infinity/RMS norm over the input, where we treat t, each
+            # element of y, and each element of adj_y 
+            # separately over the Linf, but consider all the parameters
             # together.
             if 'norm' not in adjoint_options:
                 if shapes is None:
-                    shapes = [y[-1].shape]  # [-1] because y has shape (len(t), *y0.shape)
-                # adj_t, y, adj_y, adj_params, corresponding to the order in aug_state below
-                adjoint_shapes = [torch.Size(())] + shapes + shapes + [torch.Size([sum(param.numel()
-                                                                                       for param in adjoint_params)])]
+                    shapes = [y[-1].shape]  
+                # [-1] because y has shape (len(t), *y0.shape)
+                # adj_t, y, adj_y, adj_params, 
+                # corresponding to the order in aug_state below
+                adjoint_shapes = [torch.Size(())] \
+                                    + shapes + shapes \
+                                    + [torch.Size([sum(param.numel()\
+                                           for param in adjoint_params)])]
                 adjoint_options['norm'] = _mixed_linf_rms_norm(adjoint_shapes)
             # ~Backward compatibility
 
@@ -76,14 +86,18 @@ class OdeintAdjointMethod(torch.autograd.Function):
             ##################################
 
             # [-1] because y and grad_y are both of shape (len(t), *y0.shape)
-            aug_state = [torch.zeros((), dtype=y.dtype, device=y.device), y[-1], grad_y[-1]]  # vjp_t, y, vjp_y
-            aug_state.extend([torch.zeros_like(param) for param in adjoint_params])  # vjp_params
+            aug_state = [torch.zeros((), dtype=y.dtype, device=y.device), 
+                                        y[-1], grad_y[-1]]  # vjp_t, y, vjp_y
+
+            aug_state.extend([torch.zeros_like(param) \
+                                    for param in adjoint_params])  # vjp_params
 
             ##################################
             #    Set up backward ODE func    #
             ##################################
 
-            # TODO: use a nn.Module and call odeint_adjoint to implement higher order derivatives.
+            # TODO: use a nn.Module and call odeint_adjoint 
+#            to implement higher order derivatives.
             def augmented_dynamics(t, y_aug):
                 # Dynamics of the original system augmented with
                 # the adjoint wrt y, and an integrator wrt t and args.
@@ -96,15 +110,19 @@ class OdeintAdjointMethod(torch.autograd.Function):
                     t = t_.requires_grad_(True)
                     y = y.detach().requires_grad_(True)
 
-                    # If using an adaptive solver we don't want to waste time resolving dL/dt unless we need it (which
-                    # doesn't necessarily even exist if there is piecewise structure in time), so turning off gradients
-                    # wrt t here means we won't compute that if we don't need it.
+                    # If using an adaptive solver we don't want to 
+                    # waste time resolving dL/dt unless we need it (which
+                    # doesn't necessarily even exist if there is 
+                    # piecewise structure in time), so turning off gradients
+                    # wrt t here means we won't 
+                    # compute that if we don't need it.
                     func_eval = func(t if t_requires_grad else t_, y)
 
                     # Workaround for PyTorch bug #39784
                     _t = torch.as_strided(t, (), ())
                     _y = torch.as_strided(y, (), ())
-                    _params = tuple(torch.as_strided(param, (), ()) for param in adjoint_params)
+                    _params = tuple(torch.as_strided(param, (), ()) \
+                                            for param in adjoint_params)
 
                     vjp_t, vjp_y, *vjp_params = torch.autograd.grad(
                         func_eval, (t, y) + adjoint_params, -adj_y,
@@ -114,8 +132,9 @@ class OdeintAdjointMethod(torch.autograd.Function):
                 # autograd.grad returns None if no gradient, set to zero.
                 vjp_t = torch.zeros_like(t) if vjp_t is None else vjp_t
                 vjp_y = torch.zeros_like(y) if vjp_y is None else vjp_y
-                vjp_params = [torch.zeros_like(param) if vjp_param is None else vjp_param
-                              for param, vjp_param in zip(adjoint_params, vjp_params)]
+                vjp_params = [torch.zeros_like(param) if vjp_param is None \
+                                else vjp_param for param, vjp_param \
+                                            in zip(adjoint_params, vjp_params)]
 
                 return (vjp_t, func_eval, vjp_y, *vjp_params)
 
@@ -129,10 +148,13 @@ class OdeintAdjointMethod(torch.autograd.Function):
                 time_vjps = None
             for i in range(len(t) - 1, 0, -1):
                 if t_requires_grad:
-                    # Compute the effect of moving the current time measurement point.
-                    # We don't compute this unless we need to, to save some computation.
+                    # Compute the effect of moving the 
+                    # current time measurement point.
+                    # We don't compute this unless we need to, 
+                    # to save some computation.
                     func_eval = func(t[i], y[i])
-                    dLd_cur_t = func_eval.reshape(-1).dot(grad_y[i].reshape(-1))
+                    dLd_cur_t = func_eval.reshape(-1)\
+                                            .dot(grad_y[i].reshape(-1))
                     aug_state[0] -= dLd_cur_t
                     time_vjps[i] = dLd_cur_t
 
@@ -140,11 +162,15 @@ class OdeintAdjointMethod(torch.autograd.Function):
                 aug_state = odeint(
                     augmented_dynamics, tuple(aug_state),
                     t[i - 1:i + 1].flip(0),
-                    rtol=adjoint_rtol, atol=adjoint_atol, method=adjoint_method, options=adjoint_options
+                    rtol=adjoint_rtol, atol=adjoint_atol, \
+                            method=adjoint_method, options=adjoint_options
                 )
-                aug_state = [a[1] for a in aug_state]  # extract just the t[i - 1] value
-                aug_state[1] = y[i - 1]  # update to use our forward-pass estimate of the state
-                aug_state[2] += grad_y[i - 1]  # update any gradients wrt state at this time point
+                aug_state = [a[1] for a in aug_state]  
+                # extract just the t[i - 1] value
+                aug_state[1] = y[i - 1]  
+                # update to use our forward-pass estimate of the state
+                aug_state[2] += grad_y[i - 1]  
+                # update any gradients wrt state at this time point
 
             if t_requires_grad:
                 time_vjps[0] = aug_state[0]
@@ -152,20 +178,25 @@ class OdeintAdjointMethod(torch.autograd.Function):
             adj_y = aug_state[2]
             adj_params = aug_state[3:]
 
-        return (None, None, adj_y, time_vjps, None, None, None, None, None, None, None, None, None, *adj_params)
+        return (None, None, adj_y, time_vjps, None, None, None, None, \
+                                    None, None, None, None, None, *adj_params)
 
 
-def odeint_adjoint(func, y0, t, rtol=1e-7, atol=1e-9, method=None, options=None, adjoint_rtol=None, adjoint_atol=None,
-                   adjoint_method=None, adjoint_options=None, adjoint_params=None):
+def odeint_adjoint(func, y0, t, rtol=1e-7, atol=1e-9, method=None, 
+               options=None, adjoint_rtol=None, adjoint_atol=None,
+               adjoint_method=None, adjoint_options=None, adjoint_params=None):
 
     # We need this in order to access the variables inside this module,
     # since we have no other way of getting variables along the execution path.
     if adjoint_params is None and not isinstance(func, nn.Module):
-        raise ValueError('func must be an instance of nn.Module to specify the adjoint parameters; alternatively they '
-                         'can be specified explicitly via the `adjoint_params` argument. If there are no parameters '
-                         'then it is allowable to set `adjoint_params=()`.')
+        raise ValueError('func must be an instance of nn.Module '\
+                    'to specify the adjoint parameters; alternatively they '
+                    'can be specified explicitly via the `adjoint_params` '\
+                    'argument. If there are no parameters '
+                    'then it is allowable to set `adjoint_params=()`.')
 
-    # Must come before _check_inputs as we don't want to use normalised input (in particular any changes to options)
+    # Must come before _check_inputs as we don't want to use normalised 
+    # input (in particular any changes to options)
     if adjoint_rtol is None:
         adjoint_rtol = rtol
     if adjoint_atol is None:
@@ -173,26 +204,53 @@ def odeint_adjoint(func, y0, t, rtol=1e-7, atol=1e-9, method=None, options=None,
     if adjoint_method is None:
         adjoint_method = method
     if adjoint_options is None:
-        adjoint_options = {k: v for k, v in options.items() if k != "norm"} if options is not None else {}
+        adjoint_options = {k: v for k, v in options.items() if k != "norm"} \
+                                                if options is not None else {}
     if adjoint_params is None:
         adjoint_params = tuple(func.parameters())
     else:
-        adjoint_params = tuple(adjoint_params)  # in case adjoint_params is a generator.
+        adjoint_params = tuple(adjoint_params) 
+        # in case adjoint_params is a generator.
 
     # Normalise to non-tupled input
-    shapes, func, y0, t, rtol, atol, method, options = _check_inputs(func, y0, t, rtol, atol, method, options, SOLVERS)
+    shapes, func, y0, t, rtol, atol, method, options = \
+            _check_inputs(func, y0, t, rtol, atol, method, options, SOLVERS)
 
     if "norm" in options and "norm" not in adjoint_options:
-        adjoint_shapes = [torch.Size(()), y0.shape, y0.shape] + [torch.Size([sum(param.numel() for param in adjoint_params)])]
-        adjoint_options["norm"] = _wrap_norm([_rms_norm, options["norm"], options["norm"]], adjoint_shapes)
+        if method in SYMPLECTIC:
+            param_shapes = [param_.shape for param_ in adjoint_params]
+            adj_params_len = sum(shape.numel() for shape in param_shapes)
+
+            adjoint_shapes = [torch.Size((2,)),y0.shape,y0.shape] \
+                                + [torch.Size([2*adj_params_len])]
+        else:
+            adjoint_shapes = \
+                [torch.Size(()), y0.shape, y0.shape] \
+                        + [torch.Size([sum(param.numel() \
+                            for param in adjoint_params)])]
+
+        adjoint_options["norm"] = \
+                _wrap_norm([_rms_norm, options["norm"], options["norm"]], 
+                                                                adjoint_shapes)
 
     if method in SYMPLECTIC:
-        solution = OdeintAdjointMethodSymplectic.apply(shapes, func, y0, t, rtol, atol, method, options, adjoint_rtol, adjoint_atol,
-                                            adjoint_method, adjoint_options, t.requires_grad, *adjoint_params)
+        solution = OdeintAdjointMethodSymplectic.apply(shapes, func, y0, t, 
+                                                       rtol, atol, method, 
+                                                       options, adjoint_rtol, 
+                                                       adjoint_atol, 
+                                                       adjoint_method, 
+                                                       adjoint_options, 
+                                                       t.requires_grad, 
+                                                       *adjoint_params)
     else:
-        solution = OdeintAdjointMethod.apply(shapes, func, y0, t, rtol, atol, method, options, adjoint_rtol, adjoint_atol,
-                                            adjoint_method, adjoint_options, t.requires_grad, *adjoint_params)
-
+        solution = OdeintAdjointMethod.apply(shapes, func, y0, t, 
+                                                       rtol, atol, method, 
+                                                       options, adjoint_rtol, 
+                                                       adjoint_atol, 
+                                                       adjoint_method, 
+                                                       adjoint_options, 
+                                                       t.requires_grad, 
+                                                       *adjoint_params)
     if shapes is not None:
         if method in SYMPLECTIC:
             solution = _flat_to_shape_symplectic(solution, (len(t),), shapes)

--- a/torchdiffeq/_impl/adjoint_symplectic.py
+++ b/torchdiffeq/_impl/adjoint_symplectic.py
@@ -1,13 +1,14 @@
 import torch
 import torch.nn as nn
 from .odeint import SOLVERS, odeint
-from .misc import _mixed_linf_rms_norm
+from .misc import _mixed_linf_rms_norm, _flat_to_shape
 
 
 class OdeintAdjointMethodSymplectic(torch.autograd.Function):
 
     @staticmethod
-    def forward(ctx, shapes, func, y0, t, rtol, atol, method, options, adjoint_rtol, adjoint_atol, adjoint_method,
+    def forward(ctx, shapes, func, y0, t, rtol, atol, method, options, 
+                            adjoint_rtol, adjoint_atol, adjoint_method,
                 adjoint_options, t_requires_grad, *adjoint_params):
 
         ctx.shapes = shapes
@@ -19,7 +20,8 @@ class OdeintAdjointMethodSymplectic(torch.autograd.Function):
         ctx.t_requires_grad = t_requires_grad
 
         with torch.no_grad():
-            y = odeint(func, y0, t, rtol=rtol, atol=atol, method=method, options=options)
+            y = odeint(func, y0, t, rtol=rtol, atol=atol, 
+                                        method=method, options=options)
         ctx.save_for_backward(t, y, *adjoint_params)
         return y
 
@@ -35,7 +37,11 @@ class OdeintAdjointMethodSymplectic(torch.autograd.Function):
             t_requires_grad = ctx.t_requires_grad
 
             t, y, *adjoint_params = ctx.saved_tensors
+
+            param_shapes = [param_.shape for param_ in adjoint_params]
+            adj_params_len = sum(shape.numel() for shape in param_shapes)
             adjoint_params = tuple(adjoint_params)
+
 
             ##################################
             #     Set up adjoint_options     #
@@ -46,8 +52,10 @@ class OdeintAdjointMethodSymplectic(torch.autograd.Function):
             else:
                 adjoint_options = adjoint_options.copy()
 
-            # We assume that any grid points are given to us ordered in the same direction as for the forward pass (for
-            # compatibility with setting adjoint_options = options), so we need to flip them around here.
+            # We assume that any grid points are given to us ordered 
+            # in the same direction as for the forward pass (for
+            # compatibility with setting adjoint_options = options), 
+            # so we need to flip them around here.
             try:
                 grid_points = adjoint_options['grid_points']
             except KeyError:
@@ -55,15 +63,22 @@ class OdeintAdjointMethodSymplectic(torch.autograd.Function):
             else:
                 adjoint_options['grid_points'] = grid_points.flip(0)
 
-            # Backward compatibility: by default use a mixed L-infinity/RMS norm over the input, where we treat t, each
-            # element of y, and each element of adj_y separately over the Linf, but consider all the parameters
+            # Backward compatibility: by default use a mixed 
+            # L-infinity/RMS norm over the input, where we treat t, each
+            # element of y, and each element of adj_y 
+            # separately over the Linf, but consider all the parameters
             # together.
             if 'norm' not in adjoint_options:
                 if shapes is None:
-                    shapes = [y[-1].shape]  # [-1] because y has shape (len(t), *y0.shape)
-                # adj_t, y, adj_y, adj_params, corresponding to the order in aug_state below
-                adjoint_shapes = [torch.Size(())] + shapes + shapes + [torch.Size([sum(param.numel()
-                                                                                       for param in adjoint_params)])]
+                    # [-1] because y has shape (len(t), *y0.shape)
+                    shapes = [y[-1].shape]  
+                # adj_t, y, adj_y, adj_params, 
+                # corresponding to the order in aug_state below
+                adjoint_shapes = [torch.Size(())]  \
+                                    + shapes + shapes \
+                                    + [torch.Size([sum(param.numel() \
+                                            for param in adjoint_params)])]
+
                 adjoint_options['norm'] = _mixed_linf_rms_norm(adjoint_shapes)
             # ~Backward compatibility
 
@@ -71,38 +86,65 @@ class OdeintAdjointMethodSymplectic(torch.autograd.Function):
             #      Set up initial state      #
             ##################################
 
-            # [-1] because y and grad_y are both of shape (len(t), *y0.shape)
             # Symplectic integarator considers the input as (q, p)
-            aug_state = [torch.zeros(2, dtype=y.dtype, device=y.device), y[-1], grad_y[-1]]  # vjp_t, y, vjp_y
-            aug_state.extend([torch.zeros(2*len(param), dtype=y.dtype, device=y.device) \
-                              for param in adjoint_params])  # vjp_params
+            # In symplectic integrator, 2-dim must be required.
+            # Thus, for the 1-dim dynamics, e.g. param derivateive and 
+            # t derivative, added auxiliary variable playing a role 
+            # of generalized coodinate.
+            # In other wards, 
+            # 
+            # q_theta := added auxiiliary q, p_theta := dL/d_theta
+            #       
+            #   dq_theta/dt = p_theta,
+            #   dp_theta/dt = vjp_params.
+            #
+            # Furthermore, for the correspondence, the following 
+            # coordinates are introduced.
+            #
+            # q_grad := grad_p, p_grad := grad_q
+            #
+            # Thus, augmented state should be 
+            # ([q_t,p_t],[q,p],[p_grad, q_grad],[q_theta,p_theta])
 
+            aug_state = \
+                [torch.zeros(2, dtype=y.dtype, device=y.device), 
+                 y[-1], torch.flip(grad_y[-1],dims=[0])]  
+            # [-1] because y and grad_y are both of shape (len(t), *y0.shape)
+            #  for the correspondence, grad_y should be flip.
+
+            aug_state.extend([torch.zeros(2*adj_params_len,
+                                          dtype=y.dtype,
+                                          device=y.device)])
             ##################################
             #    Set up backward ODE func    #
             ##################################
 
-            # TODO: use a nn.Module and call odeint_adjoint to implement higher order derivatives.
+            # TODO: use a nn.Module and call odeint_adjoint 
+            # to implement higher order derivatives.
             def augmented_dynamics(t, y_aug):
                 # Dynamics of the original system augmented with
                 # the adjoint wrt y, and an integrator wrt t and args.
                 y = y_aug[1]
-                adj_y = y_aug[2]
-                # ignore gradients wrt time and parameters
+                adj_y = torch.flip(y_aug[2],dims=[0])
 
                 with torch.enable_grad():
                     t_ = t.detach()
                     t = t_.requires_grad_(True)
                     y = y.detach().requires_grad_(True)
 
-                    # If using an adaptive solver we don't want to waste time resolving dL/dt unless we need it (which
-                    # doesn't necessarily even exist if there is piecewise structure in time), so turning off gradients
-                    # wrt t here means we won't compute that if we don't need it.
+                    # If using an adaptive solver we don't want to 
+                    # waste time resolving dL/dt unless we need it (which
+                    # doesn't necessarily even exist if there is 
+                    # piecewise structure in time), so turning off gradients
+                    # wrt t here means we won't 
+                    # compute that if we don't need it.
                     func_eval = func(t if t_requires_grad else t_, y)
 
                     # Workaround for PyTorch bug #39784
                     _t = torch.as_strided(t, (), ())
                     _y = torch.as_strided(y, (), ())
-                    _params = tuple(torch.as_strided(param, (), ()) for param in adjoint_params)
+                    _params = tuple(torch.as_strided(param, (), ()) \
+                                            for param in adjoint_params)
 
                     vjp_t, vjp_y, *vjp_params = torch.autograd.grad(
                         func_eval, (t, y) + adjoint_params, -adj_y,
@@ -110,18 +152,20 @@ class OdeintAdjointMethodSymplectic(torch.autograd.Function):
                     )
 
                 # autograd.grad returns None if no gradient, set to zero.
-                vjp_t = torch.zeros(2*len(t.reshape(-1)), dtype=y.dtype, device=y.device) \
-                                    if vjp_t is None else \
-                                        torch.cat([vjp_t, torch.zeros(len(t))])
+                p_t = y_aug[0][1:]
+                p_theta = y_aug[3][adj_params_len:]
 
+                vjp_t = torch.zeros_like(t).reshape(-1) if vjp_t is None else vjp_t
+                vjp_t = torch.cat([p_t,vjp_t])
                 vjp_y = torch.zeros_like(y) if vjp_y is None else vjp_y
+                vjp_params = tuple([torch.zeros_like(param) if vjp_param is None else vjp_param
+                              for param, vjp_param in zip(adjoint_params, vjp_params)])
+                vjp_params = torch.cat([vjp_para_.reshape(-1) for vjp_para_ in vjp_params])
+                vjp_params = torch.cat([p_theta, vjp_params])
 
-                vjp_params = [torch.zeros(2*len(param), dtype=y.dtype, device=y.device) 
-                              if vjp_param is None \
-                              else torch.cat([vjp_param,torch.zeros(len(vjp_param))]) \
-                              for param, vjp_param in zip(adjoint_params, vjp_params)]
+                vjp_y = torch.flip(vjp_y, dims=[0])
 
-                return (vjp_t, func_eval, vjp_y, *vjp_params)
+                return (vjp_t, func_eval, vjp_y, vjp_params)
             ##################################
             #       Solve adjoint ODE        #
             ##################################
@@ -136,7 +180,7 @@ class OdeintAdjointMethodSymplectic(torch.autograd.Function):
                     # We don't compute this unless we need to, to save some computation.
                     func_eval = func(t[i], y[i])
                     dLd_cur_t = func_eval.reshape(-1).dot(grad_y[i].reshape(-1))
-                    aug_state[0] -= dLd_cur_t
+                    aug_state[0][1:] -= dLd_cur_t
                     time_vjps[i] = dLd_cur_t
 
                 # Run the augmented system backwards in time.
@@ -147,13 +191,16 @@ class OdeintAdjointMethodSymplectic(torch.autograd.Function):
                 )
                 aug_state = [a[1] for a in aug_state]  # extract just the t[i - 1] value
                 aug_state[1] = y[i - 1]  # update to use our forward-pass estimate of the state
-                aug_state[2] += grad_y[i - 1]  # update any gradients wrt state at this time point
+                aug_state[2] += torch.flip(grad_y[i - 1],dims=[0]) 
+                # update any gradients wrt state at this time point
 
             if t_requires_grad:
-                time_vjps[0], = torch.chunk(aug_state[0],2)
+                time_vjps[0] = aug_state[0][1:]
 
             adj_y = aug_state[2]
-            adj_params = [param[:len(param)//2] for param in aug_state[3:]]
+            adj_y = torch.flip(adj_y,dims=[0])
+            adj_params = aug_state[3][adj_params_len:]
+            adj_params = _flat_to_shape(adj_params,(),param_shapes)
 
         return (None, None, adj_y, time_vjps, None, None, None, None, None, None, None, None, None, *adj_params)
 

--- a/torchdiffeq/_impl/adjoint_symplectic.py
+++ b/torchdiffeq/_impl/adjoint_symplectic.py
@@ -1,0 +1,157 @@
+import torch
+import torch.nn as nn
+from .odeint import SOLVERS, odeint
+from .misc import _mixed_linf_rms_norm
+
+
+class OdeintAdjointMethodSymplectic(torch.autograd.Function):
+
+    @staticmethod
+    def forward(ctx, shapes, func, y0, t, rtol, atol, method, options, adjoint_rtol, adjoint_atol, adjoint_method,
+                adjoint_options, t_requires_grad, *adjoint_params):
+
+        ctx.shapes = shapes
+        ctx.func = func
+        ctx.adjoint_rtol = adjoint_rtol
+        ctx.adjoint_atol = adjoint_atol
+        ctx.adjoint_method = adjoint_method
+        ctx.adjoint_options = adjoint_options
+        ctx.t_requires_grad = t_requires_grad
+
+        with torch.no_grad():
+            y = odeint(func, y0, t, rtol=rtol, atol=atol, method=method, options=options)
+        ctx.save_for_backward(t, y, *adjoint_params)
+        return y
+
+    @staticmethod
+    def backward(ctx, grad_y):
+        with torch.no_grad():
+            shapes = ctx.shapes
+            func = ctx.func
+            adjoint_rtol = ctx.adjoint_rtol
+            adjoint_atol = ctx.adjoint_atol
+            adjoint_method = ctx.adjoint_method
+            adjoint_options = ctx.adjoint_options
+            t_requires_grad = ctx.t_requires_grad
+
+            t, y, *adjoint_params = ctx.saved_tensors
+            adjoint_params = tuple(adjoint_params)
+
+            ##################################
+            #     Set up adjoint_options     #
+            ##################################
+
+            if adjoint_options is None:
+                adjoint_options = {}
+            else:
+                adjoint_options = adjoint_options.copy()
+
+            # We assume that any grid points are given to us ordered in the same direction as for the forward pass (for
+            # compatibility with setting adjoint_options = options), so we need to flip them around here.
+            try:
+                grid_points = adjoint_options['grid_points']
+            except KeyError:
+                pass
+            else:
+                adjoint_options['grid_points'] = grid_points.flip(0)
+
+            # Backward compatibility: by default use a mixed L-infinity/RMS norm over the input, where we treat t, each
+            # element of y, and each element of adj_y separately over the Linf, but consider all the parameters
+            # together.
+            if 'norm' not in adjoint_options:
+                if shapes is None:
+                    shapes = [y[-1].shape]  # [-1] because y has shape (len(t), *y0.shape)
+                # adj_t, y, adj_y, adj_params, corresponding to the order in aug_state below
+                adjoint_shapes = [torch.Size(())] + shapes + shapes + [torch.Size([sum(param.numel()
+                                                                                       for param in adjoint_params)])]
+                adjoint_options['norm'] = _mixed_linf_rms_norm(adjoint_shapes)
+            # ~Backward compatibility
+
+            ##################################
+            #      Set up initial state      #
+            ##################################
+
+            # [-1] because y and grad_y are both of shape (len(t), *y0.shape)
+            # Symplectic integarator considers the input as (q, p)
+            aug_state = [torch.zeros(2, dtype=y.dtype, device=y.device), y[-1], grad_y[-1]]  # vjp_t, y, vjp_y
+            aug_state.extend([torch.zeros(2*len(param)) for param in adjoint_params])  # vjp_params
+
+            ##################################
+            #    Set up backward ODE func    #
+            ##################################
+
+            # TODO: use a nn.Module and call odeint_adjoint to implement higher order derivatives.
+            def augmented_dynamics(t, y_aug):
+                # Dynamics of the original system augmented with
+                # the adjoint wrt y, and an integrator wrt t and args.
+                y = y_aug[1]
+                adj_y = y_aug[2]
+                # ignore gradients wrt time and parameters
+
+                with torch.enable_grad():
+                    t_ = t.detach()
+                    t = t_.requires_grad_(True)
+                    y = y.detach().requires_grad_(True)
+
+                    # If using an adaptive solver we don't want to waste time resolving dL/dt unless we need it (which
+                    # doesn't necessarily even exist if there is piecewise structure in time), so turning off gradients
+                    # wrt t here means we won't compute that if we don't need it.
+                    func_eval = func(t if t_requires_grad else t_, y)
+
+                    # Workaround for PyTorch bug #39784
+                    _t = torch.as_strided(t, (), ())
+                    _y = torch.as_strided(y, (), ())
+                    _params = tuple(torch.as_strided(param, (), ()) for param in adjoint_params)
+
+                    vjp_t, vjp_y, *vjp_params = torch.autograd.grad(
+                        func_eval, (t, y) + adjoint_params, -adj_y,
+                        allow_unused=True, retain_graph=True
+                    )
+
+                # autograd.grad returns None if no gradient, set to zero.
+                vjp_t = torch.zeros(2*len(t.reshape(-1))) if vjp_t is None else \
+                            torch.cat([vjp_t, torch.zeros(len(t))])
+
+                vjp_y = torch.zeros_like(y) if vjp_y is None else vjp_y
+
+                vjp_params = [torch.zeros(2*len(param)) if vjp_param is None 
+                              else torch.cat([vjp_param,torch.zeros(len(vjp_param))])
+                              for param, vjp_param in zip(adjoint_params, vjp_params)]
+
+                return (vjp_t, func_eval, vjp_y, *vjp_params)
+            ##################################
+            #       Solve adjoint ODE        #
+            ##################################
+
+            if t_requires_grad:
+                time_vjps = torch.empty(len(t), dtype=t.dtype, device=t.device)
+            else:
+                time_vjps = None
+            for i in range(len(t) - 1, 0, -1):
+                if t_requires_grad:
+                    # Compute the effect of moving the current time measurement point.
+                    # We don't compute this unless we need to, to save some computation.
+                    func_eval = func(t[i], y[i])
+                    dLd_cur_t = func_eval.reshape(-1).dot(grad_y[i].reshape(-1))
+                    aug_state[0] -= dLd_cur_t
+                    time_vjps[i] = dLd_cur_t
+
+                # Run the augmented system backwards in time.
+                aug_state = odeint(
+                    augmented_dynamics, tuple(aug_state),
+                    t[i - 1:i + 1].flip(0),
+                    rtol=adjoint_rtol, atol=adjoint_atol, method=adjoint_method, options=adjoint_options
+                )
+                aug_state = [a[1] for a in aug_state]  # extract just the t[i - 1] value
+                aug_state[1] = y[i - 1]  # update to use our forward-pass estimate of the state
+                aug_state[2] += grad_y[i - 1]  # update any gradients wrt state at this time point
+
+            if t_requires_grad:
+                time_vjps[0], = torch.chunk(aug_state[0],2)
+
+            adj_y = aug_state[2]
+            adj_params = [param[:len(param)//2] for param in aug_state[3:]]
+
+        return (None, None, adj_y, time_vjps, None, None, None, None, None, None, None, None, None, *adj_params)
+
+

--- a/torchdiffeq/_impl/fixed_grid_symplectic.py
+++ b/torchdiffeq/_impl/fixed_grid_symplectic.py
@@ -13,7 +13,8 @@ _c2 = 1.0 / (1.0 - pow(2.0,2.0/3.0))
 
 
 class Yoshida4th(FixedGridODESolver):
-    "support only H = p^2/2 + V(q) form"
+    "support only H = p^2/2 + V(q,theta) form"
+    order = 4
 
     def __init__(self, eps=0., **kwargs):
         super(Yoshida4th, self).__init__(**kwargs)

--- a/torchdiffeq/_impl/fixed_grid_symplectic.py
+++ b/torchdiffeq/_impl/fixed_grid_symplectic.py
@@ -19,28 +19,24 @@ class Yoshida4th(FixedGridODESolver):
         self.eps = torch.as_tensor(eps, dtype=self.dtype, device=self.device)
 
     def _step_symplectic(self, func, y, t, h, h2):
-        dy = torch.zeros(y.size())
+        dy = torch.zeros(y.size(),dtype=self.dtype,device=self.device)
         n = len(y) // 2
         k_ = func(t + self.eps, y)
-        for i in range(n):
-            dy[i] = h*_c1*k_[i] + h2*_c1*_b1*k_[n+i]
-            dy[n+i] = h*_b1*k_[n+i]
+        dy[:n] = h*_c1*k_[:n] + h2*_c1*_b1*k_[n:]
+        dy[n:] = h*_b1*k_[n:]
 
         k_ = func(t + self.eps, y + dy)
-        for i in range(n):
-            dy[i] = dy[i] \
-                         + h*_c2*k_[i] + h2*_c2*_b2*k_[n+i]
-            dy[n+i] = dy[n+i] + h*_b2*k_[n+i]
+        dy[:n] = dy[:n] \
+                + h*_c2*k_[:n] + h2*_c2*_b2*k_[n:]
+        dy[n:] = dy[n:] + h*_b2*k_[n:]
 
         k_ = func(t + self.eps, y + dy)
-        for i in range(n):
-            dy[i] = dy[i] \
-                         + h*_c1*k_[i] + h2*_c1*_b2*k_[n+i]
-            dy[n+i] = dy[n+i] + h*_b2*k_[n+i]
+        dy[:n] = dy[:n] \
+                + h*_c1*k_[:n] + h2*_c1*_b2*k_[n:]
+        dy[n:] = dy[n:] + h*_b2*k_[n:]
 
         k_ = func(t + self.eps, y + dy)
-        for i in range(n):
-            dy[n+i] = dy[n+i] + h*_b1*k_[n+i]
+        dy[n:] = dy[n:] + h*_b1*k_[n:]
 
         return dy
 

--- a/torchdiffeq/_impl/fixed_grid_symplectic.py
+++ b/torchdiffeq/_impl/fixed_grid_symplectic.py
@@ -4,7 +4,6 @@
 
 import torch
 from .solvers import FixedGridODESolver
-from .rk_common import rk4_alt_step_func
 
 # symplectic integrators constatn 
 _b1 = 1.0/(4.0 - 2.0*pow(2.0,1.0/3.0))

--- a/torchdiffeq/_impl/fixed_grid_symplectic.py
+++ b/torchdiffeq/_impl/fixed_grid_symplectic.py
@@ -1,0 +1,63 @@
+# Implemention of symplectic integrator.
+# Whole input as (q,p) and  the shape is (bath_size, 2N)
+# where N is the number of paritcles 
+
+import torch
+from .solvers import FixedGridODESolver
+from .rk_common import rk4_alt_step_func
+
+# symplectic integrators constatn 
+_b1 = 1.0/(4.0 - 2.0*pow(2.0,1.0/3.0))
+_b2 = (1.0 - pow(2.0,1.0/3.0))/(4.0 - 2.0*pow(2.0,1.0/3.0))
+_c1 = 1.0 / (2.0 - pow(2.0,1.0/3.0))
+_c2 = 1.0 / (1.0 - pow(2.0,2.0/3.0))
+
+
+class Yoshida4th(FixedGridODESolver):
+    def __init__(self, eps=0., **kwargs):
+        super(Yoshida4th, self).__init__(**kwargs)
+        self.eps = torch.as_tensor(eps, dtype=self.dtype, device=self.device)
+
+    def _step_symplectic(self, func, y, dy, t, h, h2, bs, n):
+        k_ = func(t + self.eps, y)
+        for i in range(bs):
+            for j in range(n):
+                dy[2*n*i+j] = h*_c1*k_[2*n*i+j] + h2*_c1*_b1*k_[2*n*i+n+j]
+                dy[2*n*i+n+j] = h*_b1*k_[2*n*i+n+j]
+
+        k_ = func(t + self.eps, y + dy)
+        for i in range(bs):
+            for j in range(n):
+                dy[2*n*i+j] = dy[2*n*i+j] \
+                             + h*_c2*k_[2*n*i+j] + h2*_c2*_b2*k_[2*n*i+n+j]
+                dy[2*n*i+n+j] = dy[2*n*i+n+j] + h*_b2*k_[2*n*i+n+j]
+
+        k_ = func(t + self.eps, y + dy)
+        for i in range(bs):
+            for j in range(n):
+                dy[2*n*i+j] = dy[2*n*i+j] \
+                             + h*_c1*k_[2*n*i+j] + h2*_c1*_b2*k_[2*n*i+n+j]
+                dy[2*n*i+n+j] = dy[2*n*i+n+j] + h*_b2*k_[2*n*i+n+j]
+
+        k_ = func(t + self.eps, y + dy)
+        for i in range(bs):
+            for j in range(n):
+                dy[2*n*i+n+j] = dy[2*n*i+n+j] + h*_b1*k_[2*n*i+n+j]
+
+        return dy
+
+    def _step_func(self, func, t, dt, y):
+        h2 = dt * dt
+        h = dt
+        dy = torch.zeros(y.size())
+
+        if len(func.shapes) < 3:
+            config_shape= func.shapes[0]
+            bs = config_shape[0]
+            n = config_shape[1] // 2
+            return self._step_symplectic(func, y, dy, t, h, h2, bs, n)
+        else:
+            return rk4_alt_step_func(func, t + self.eps, dt - 2 * self.eps, y)
+
+
+

--- a/torchdiffeq/_impl/fixed_grid_symplectic.py
+++ b/torchdiffeq/_impl/fixed_grid_symplectic.py
@@ -18,46 +18,35 @@ class Yoshida4th(FixedGridODESolver):
         super(Yoshida4th, self).__init__(**kwargs)
         self.eps = torch.as_tensor(eps, dtype=self.dtype, device=self.device)
 
-    def _step_symplectic(self, func, y, dy, t, h, h2, bs, n):
+    def _step_symplectic(self, func, y, t, h, h2):
+        dy = torch.zeros(y.size())
+        n = len(y) // 2
         k_ = func(t + self.eps, y)
-        for i in range(bs):
-            for j in range(n):
-                dy[2*n*i+j] = h*_c1*k_[2*n*i+j] + h2*_c1*_b1*k_[2*n*i+n+j]
-                dy[2*n*i+n+j] = h*_b1*k_[2*n*i+n+j]
+        for i in range(n):
+            dy[i] = h*_c1*k_[i] + h2*_c1*_b1*k_[n+i]
+            dy[n+i] = h*_b1*k_[n+i]
 
         k_ = func(t + self.eps, y + dy)
-        for i in range(bs):
-            for j in range(n):
-                dy[2*n*i+j] = dy[2*n*i+j] \
-                             + h*_c2*k_[2*n*i+j] + h2*_c2*_b2*k_[2*n*i+n+j]
-                dy[2*n*i+n+j] = dy[2*n*i+n+j] + h*_b2*k_[2*n*i+n+j]
+        for i in range(n):
+            dy[i] = dy[i] \
+                         + h*_c2*k_[i] + h2*_c2*_b2*k_[n+i]
+            dy[n+i] = dy[n+i] + h*_b2*k_[n+i]
 
         k_ = func(t + self.eps, y + dy)
-        for i in range(bs):
-            for j in range(n):
-                dy[2*n*i+j] = dy[2*n*i+j] \
-                             + h*_c1*k_[2*n*i+j] + h2*_c1*_b2*k_[2*n*i+n+j]
-                dy[2*n*i+n+j] = dy[2*n*i+n+j] + h*_b2*k_[2*n*i+n+j]
+        for i in range(n):
+            dy[i] = dy[i] \
+                         + h*_c1*k_[i] + h2*_c1*_b2*k_[n+i]
+            dy[n+i] = dy[n+i] + h*_b2*k_[n+i]
 
         k_ = func(t + self.eps, y + dy)
-        for i in range(bs):
-            for j in range(n):
-                dy[2*n*i+n+j] = dy[2*n*i+n+j] + h*_b1*k_[2*n*i+n+j]
+        for i in range(n):
+            dy[n+i] = dy[n+i] + h*_b1*k_[n+i]
 
         return dy
 
     def _step_func(self, func, t, dt, y):
         h2 = dt * dt
         h = dt
-        dy = torch.zeros(y.size())
 
-        if len(func.shapes) < 3:
-            config_shape= func.shapes[0]
-            bs = config_shape[0]
-            n = config_shape[1] // 2
-            return self._step_symplectic(func, y, dy, t, h, h2, bs, n)
-        else:
-            return rk4_alt_step_func(func, t + self.eps, dt - 2 * self.eps, y)
-
-
+        return self._step_symplectic(func, y, t, h, h2)
 

--- a/torchdiffeq/_impl/misc.py
+++ b/torchdiffeq/_impl/misc.py
@@ -154,9 +154,10 @@ class _TupleFunc(torch.nn.Module):
 
 
 class _ReverseFunc(torch.nn.Module):
-    def __init__(self, base_func):
+    def __init__(self, base_func,shapes):
         super(_ReverseFunc, self).__init__()
         self.base_func = base_func
+        self.shapes = shapes
 
     def forward(self, t, y):
         return -self.base_func(-t, y)
@@ -209,7 +210,7 @@ def _check_inputs(func, y0, t, rtol, atol, method, options, SOLVERS):
     _assert_floating('t', t)
     if _decreasing(t):
         t = -t
-        func = _ReverseFunc(func)
+        func = _ReverseFunc(func,shapes)
         try:
             grid_points = options['grid_points']
         except KeyError:

--- a/torchdiffeq/_impl/misc.py
+++ b/torchdiffeq/_impl/misc.py
@@ -189,6 +189,15 @@ class _ReverseFunc(torch.nn.Module):
         return -self.base_func(-t, y)
 
 
+class _ReverseFuncSymplectic(torch.nn.Module):
+    def __init__(self, base_func):
+        super(_ReverseFuncSymplectic, self).__init__()
+        self.base_func = base_func
+
+    def forward(self, t, y):
+        return self.base_func(-t, y)
+
+
 def _reform_inputs_for_symplectic(inputs):
     device = inputs[0].device
     dtype = inputs[0].dtype
@@ -256,7 +265,10 @@ def _check_inputs(func, y0, t, rtol, atol, method, options, SOLVERS):
     _assert_floating('t', t)
     if _decreasing(t):
         t = -t
-        func = _ReverseFunc(func)
+        if method in SYMPLECTIC:
+            func = _ReverseFuncSymplectic(func)
+        else:
+            func = _ReverseFunc(func)
         try:
             grid_points = options['grid_points']
         except KeyError:

--- a/torchdiffeq/_impl/misc.py
+++ b/torchdiffeq/_impl/misc.py
@@ -190,8 +190,10 @@ class _ReverseFunc(torch.nn.Module):
 
 
 def _reform_inputs_for_symplectic(inputs):
-    tensor_l = torch.tensor([])
-    tensor_r = torch.tensor([])
+    device = inputs[0].device
+    dtype = inputs[0].dtype
+    tensor_l = torch.tensor([],device=device,dtype=dtype)
+    tensor_r = torch.tensor([],device=device,dtype=dtype)
     shapes = []
     for tensor_ in inputs:
         assert tensor_.shape[-1] % 2 == 0, 'using symplectic, input dimension must be dividable by two'

--- a/torchdiffeq/_impl/odeint.py
+++ b/torchdiffeq/_impl/odeint.py
@@ -5,7 +5,7 @@ from .fixed_grid import Euler, Midpoint, RK4
 from .fixed_grid_symplectic import Yoshida4th
 from .fixed_adams import AdamsBashforth, AdamsBashforthMoulton
 from .dopri8 import Dopri8Solver
-from .misc import _check_inputs, _flat_to_shape
+from .misc import _check_inputs, _flat_to_shape, _flat_to_shape_symplectic, SYMPLECTIC
 
 SOLVERS = {
     'dopri8': Dopri8Solver,
@@ -61,11 +61,15 @@ def odeint(func, y0, t, rtol=1e-7, atol=1e-9, method=None, options=None):
     Raises:
         ValueError: if an invalid `method` is provided.
     """
+
     shapes, func, y0, t, rtol, atol, method, options = _check_inputs(func, y0, t, rtol, atol, method, options, SOLVERS)
 
     solver = SOLVERS[method](func=func, y0=y0, rtol=rtol, atol=atol, **options)
     solution = solver.integrate(t)
 
     if shapes is not None:
-        solution = _flat_to_shape(solution, (len(t),), shapes)
+        if method in SYMPLECTIC:
+            solution = _flat_to_shape_symplectic(solution, (len(t),), shapes)
+        else:
+            solution = _flat_to_shape(solution, (len(t),), shapes)
     return solution

--- a/torchdiffeq/_impl/odeint.py
+++ b/torchdiffeq/_impl/odeint.py
@@ -5,7 +5,8 @@ from .fixed_grid import Euler, Midpoint, RK4
 from .fixed_grid_symplectic import Yoshida4th
 from .fixed_adams import AdamsBashforth, AdamsBashforthMoulton
 from .dopri8 import Dopri8Solver
-from .misc import _check_inputs, _flat_to_shape, _flat_to_shape_symplectic, SYMPLECTIC
+from .misc import _check_inputs, _flat_to_shape, \
+                 _flat_to_shape_symplectic, SYMPLECTIC
 
 SOLVERS = {
     'dopri8': Dopri8Solver,

--- a/torchdiffeq/_impl/odeint.py
+++ b/torchdiffeq/_impl/odeint.py
@@ -2,6 +2,7 @@ from .dopri5 import Dopri5Solver
 from .bosh3 import Bosh3Solver
 from .adaptive_heun import AdaptiveHeunSolver
 from .fixed_grid import Euler, Midpoint, RK4
+from .fixed_grid_symplectic import Yoshida4th
 from .fixed_adams import AdamsBashforth, AdamsBashforthMoulton
 from .dopri8 import Dopri8Solver
 from .misc import _check_inputs, _flat_to_shape
@@ -14,6 +15,7 @@ SOLVERS = {
     'euler': Euler,
     'midpoint': Midpoint,
     'rk4': RK4,
+    'yoshida4th':Yoshida4th,
     'explicit_adams': AdamsBashforth,
     'implicit_adams': AdamsBashforthMoulton,
     # Backward compatibility: use the same name as before


### PR DESCRIPTION
Dear  @rtqichen.
I implement 4th order symplectic integrator for adjoins method. It might be related to this article, but they seems not to use the adjoint method. ["Sparse Symplectically Integrated Neural Networks", Daniel M. DiPietro, Shiying Xiong, B. Zhu Published 2020 Computer Science, Physics, Mathematics ArXiv
](https://www.semanticscholar.org/paper/Sparse-Symplectically-Integrated-Neural-Networks-DiPietro-Xiong/8e67c6220fc42065cf48a137286714fe94b44213#paper-header)For my lack of implementation skill, my adjoint method can be used for restricted Hamiltonian dynamics. For physics, however, I think this implementation is useful. If you don't mind, would you do me a favor to check this codes and accept pull request? I'm looking forward to seeing your advices to this implementation and my pull request if you have. 
Sincerely.