### PR TITLE
Patch for step_t, jump_t, and perturb

### DIFF
--- a/FURTHER_DOCUMENTATION.md
+++ b/FURTHER_DOCUMENTATION.md
@@ -15,9 +15,9 @@ For these solvers, `rtol` and `atol` correspond to the tolerances for accepting/
 
 - `dtype=torch.float64`: what dtype to use for timelike quantities. Setting this to `torch.float32` will improve speed but may produce underflow errors more easily.
 
-- `step_t=None`: Times that a step must me made to. In particular this is useful when `func` has kinks (derivative discontinuities) at these times, as the solver then does not need to (slowly) discover these for itself. If passed this should be an ordered one dimensional `torch.Tensor`.
+- `step_t=None`: Times that a step must me made to. In particular this is useful when `func` has kinks (derivative discontinuities) at these times, as the solver then does not need to (slowly) discover these for itself. If passed this should be a `torch.Tensor`.
 
-- `jump_t=None`: Times that a step must be made to, and `func` re-evaluated at. In particular this is useful when `func` has discontinuites at these times, as then the solver knows that the final function evaluation of the previous step is not equal to the first function evaluation of this step. (i.e. the FSAL property does not hold at this point.) If passed this should be an ordered one dimensional `torch.Tensor`. Note that this is not efficient on the GPU when using PyTorch 1.6.0 or earlier.
+- `jump_t=None`: Times that a step must be made to, and `func` re-evaluated at. In particular this is useful when `func` has discontinuites at these times, as then the solver knows that the final function evaluation of the previous step is not equal to the first function evaluation of this step. (i.e. the FSAL property does not hold at this point.) If passed this should be a `torch.Tensor`. Note that this may not be efficient when using PyTorch 1.6.0 or earlier.
 
 - `norm`: What norm to compute the accept/reject criterion with respect to. Given tensor input, this defaults to an RMS norm. Given tupled input, it computes an RMS norm over each tensor, and then takes a max over the tuple, producing a mixed L-infinity/RMS norm. If passed this should be a function consuming a single tensor of shape the same as `y0` (given tensor input) or a single tensor of shape `(sum(y.numel() for y in y0),)` (given tupled input), and return a scalar tensor corresponding to its norm.
 
@@ -27,12 +27,9 @@ For these solvers, `rtol` and `atol` correspond to the tolerances for accepting/
 
 - `grid_constructor=None`: A more fine-grained way of setting the steps, by setting these particular locations as the locations of the steps. Should be a callable `func, y0, t -> grid`, transforming the arguments `func, y0, t` of `odeint` into the desired grid (which should be a one dimensional tensor).
 
+- `perturb`: Defaults to False. If True, then automatically add small perturbations to the start and end of each step, so that stepping to discontinuities works. Note that this this may not be efficient when using PyTorch 1.6.0 or earlier.
+
 Individual solvers also offer certain options.
-
-**euler, midpoint, rk4:**<br>
-For these solvers, `rtol` and `atol` are ignored. These solvers also support:
-
-- `perturb`: Defaults to False. If True, then automatically add small perturbations to the start and end of each step, so that stepping to discontinuities works. Note that this is not efficient on the GPU when using PyTorch 1.6.0 or earlier.
 
 **explicit_adams:**<br>
 For this solver, `rtol` and `atol` are ignored. This solver also supports:

--- a/FURTHER_DOCUMENTATION.md
+++ b/FURTHER_DOCUMENTATION.md
@@ -15,9 +15,9 @@ For these solvers, `rtol` and `atol` correspond to the tolerances for accepting/
 
 - `dtype=torch.float64`: what dtype to use for timelike quantities. Setting this to `torch.float32` will improve speed but may produce underflow errors more easily.
 
-- `grid_points=None`: The locations of any discontinuities or derivative discontinuities in the vector field. Crossing these will make the solver suddenly take a larger error, so it will reject the step and slow down to resolve the discontinuity. Once it has done that, then it must speed back up again. If the locations of these discontinuities is known in advance, then the solver can be told about their locations and make a step exactly to them. If passed this should be an ordered one dimensional `torch.Tensor`.
+- `step_t=None`: Times that a step must me made to. In particular this is useful when `func` has kinks (derivative discontinuities) at these times, as the solver then does not need to (slowly) discover these for itself. If passed this should be an ordered one dimensional `torch.Tensor`.
 
-- `eps=0.`: A small perturbation either side of each value in `grid_points` to evaluate at. If the vector field is discontinuous then this ensures that evaluations are performed the correct size of the discontinuity. If used it usually best to just set this to a small number like `1e-5`.
+- `jump_t=None`: Times that a step must be made to, and `func` re-evaluated at. In particular this is useful when `func` has discontinuites at these times, as then the solver knows that the final function evaluation of the previous step is not equal to the first function evaluation of this step. (i.e. the FSAL property does not hold at this point.) If passed this should be an ordered one dimensional `torch.Tensor`. Note that this is not efficient on the GPU when using PyTorch 1.6.0 or earlier.
 
 - `norm`: What norm to compute the accept/reject criterion with respect to. Given tensor input, this defaults to an RMS norm. Given tupled input, it computes an RMS norm over each tensor, and then takes a max over the tuple, producing a mixed L-infinity/RMS norm. If passed this should be a function consuming a single tensor of shape the same as `y0` (given tensor input) or a single tensor of shape `(sum(y.numel() for y in y0),)` (given tupled input), and return a scalar tensor corresponding to its norm.
 
@@ -32,7 +32,7 @@ Individual solvers also offer certain options.
 **euler, midpoint, rk4:**<br>
 For these solvers, `rtol` and `atol` are ignored. These solvers also support:
 
-- `eps=0.`: Analogous to the `eps` argument of the adaptive solvers, this adds a small perturbation to each end of the every step (not just the grid points), to help stay the right side of discontinuities.
+- `perturb`: Defaults to False. If True, then automatically add small perturbations to the start and end of each step, so that stepping to discontinuities works. Note that this is not efficient on the GPU when using PyTorch 1.6.0 or earlier.
 
 **explicit_adams:**<br>
 For this solver, `rtol` and `atol` are ignored. This solver also supports:

--- a/tests/odeint_tests.py
+++ b/tests/odeint_tests.py
@@ -18,9 +18,14 @@ class TestSolverError(unittest.TestCase):
             for dtype in DTYPES:
                 for device in DEVICES:
                     for method in METHODS:
-                        if dtype == torch.float32 and method == 'dopri8':
-                            continue
-                        kwargs = dict(rtol=1e-12, atol=1e-14) if method == 'dopri8' else dict()
+
+                        kwargs = dict()
+                        # Have to increase tolerance for dopri8.
+                        if method == 'dopri8' and dtype == torch.float64:
+                            kwargs = dict(rtol=1e-12, atol=1e-14)
+                        if method == 'dopri8' and dtype == torch.float32:
+                            kwargs = dict(rtol=1e-7, atol=1e-7)
+
                         problems = PROBLEMS if method in ADAPTIVE_METHODS else ('constant',)
                         for ode in problems:
                             if method in ['adaptive_heun', 'bosh3']:
@@ -104,10 +109,6 @@ class TestDiscontinuities(unittest.TestCase):
             for dtype in DTYPES:
                 for device in DEVICES:
                     for method in ADAPTIVE_METHODS:
-
-                        # Why is this case skipped over?
-                        if dtype == torch.float32 and method == 'dopri8':
-                            continue
 
                         with self.subTest(adjoint=adjoint, dtype=dtype, device=device, method=method):
 

--- a/tests/odeint_tests.py
+++ b/tests/odeint_tests.py
@@ -5,8 +5,7 @@ import warnings
 import torch
 import torchdiffeq
 
-from problems import (construct_problem, PROBLEMS, DTYPES, DEVICES, METHODS, ADAPTIVE_METHODS, FIXED_METHODS,
-                      ADAMS_METHODS)
+from problems import (construct_problem, PROBLEMS, DTYPES, DEVICES, METHODS, ADAPTIVE_METHODS, FIXED_METHODS)
 
 
 def rel_error(true, estimate):
@@ -142,10 +141,6 @@ class TestDiscontinuities(unittest.TestCase):
             for dtype in DTYPES:
                 for device in DEVICES:
                     for method in FIXED_METHODS:
-
-                        # TODO: implement perturb for fixed step adams methods.
-                        if method in ADAMS_METHODS:
-                            continue
                         for perturb in (True, False):
                             with self.subTest(adjoint=adjoint, dtype=dtype, device=device, method=method,
                                               perturb=perturb):

--- a/torchdiffeq/_impl/adjoint.py
+++ b/torchdiffeq/_impl/adjoint.py
@@ -65,15 +65,6 @@ class OdeintAdjointMethod(torch.autograd.Function):
             else:
                 adjoint_options = adjoint_options.copy()
 
-            # We assume that any grid points are given to us ordered in the same direction as for the forward pass (for
-            # compatibility with setting adjoint_options = options), so we need to flip them around here.
-            try:
-                grid_points = adjoint_options['grid_points']
-            except KeyError:
-                pass
-            else:
-                adjoint_options['grid_points'] = grid_points.flip(0)
-
             # Backward compatibility: by default use a mixed L-infinity/RMS norm over the input, where we treat t, each
             # element of y, and each element of adj_y separately over the Linf, but consider all the parameters
             # together.

--- a/torchdiffeq/_impl/fixed_adams.py
+++ b/torchdiffeq/_impl/fixed_adams.py
@@ -4,6 +4,7 @@ import torch
 import warnings
 from .solvers import FixedGridODESolver
 from .misc import _compute_error_ratio, _linf_norm
+from .misc import Perturb
 from .rk_common import rk4_alt_step_func
 
 _BASHFORTH_COEFFICIENTS = [
@@ -192,7 +193,7 @@ class AdamsBashforthMoulton(FixedGridODESolver):
         return error_ratio < 1
 
     def _step_func(self, func, t0, dt, t1, y0):
-        f0 = func(t0, y0, perturb=True if self.perturb else None)
+        f0 = func(t0, y0, perturb=Perturb.NEXT if self.perturb else Perturb.NONE)
         self._update_history(t0, f0)
         order = min(len(self.prev_f), self.max_order - 1)
         if order < _MIN_ORDER - 1:
@@ -210,7 +211,7 @@ class AdamsBashforthMoulton(FixedGridODESolver):
                 converged = False
                 for _ in range(self.max_iters):
                     dy_old = dy
-                    f = func(t1, y0 + dy, perturb=False if self.perturb else None)
+                    f = func(t1, y0 + dy, perturb=Perturb.PREV if self.perturb else Perturb.NONE)
                     dy = (dt * (moulton_coeffs[0]) * f).type_as(y0) + delta  # moulton is float64 so cast back
                     converged = self._has_converged(dy_old, dy)
                     if converged:

--- a/torchdiffeq/_impl/fixed_adams.py
+++ b/torchdiffeq/_impl/fixed_adams.py
@@ -191,34 +191,34 @@ class AdamsBashforthMoulton(FixedGridODESolver):
         error_ratio = _compute_error_ratio(torch.abs(y0 - y1), self.rtol, self.atol, y0, y1, _linf_norm)
         return error_ratio < 1
 
-    def _step_func(self, func, t, dt, y):
-        f0 = func(t, y)
-        self._update_history(t, f0)
+    def _step_func(self, func, t0, dt, t1, y0):
+        f0 = func(t0, y0, perturb=True if self.perturb else None)
+        self._update_history(t0, f0)
         order = min(len(self.prev_f), self.max_order - 1)
         if order < _MIN_ORDER - 1:
             # Compute using RK4.
-            return rk4_alt_step_func(func, t, dt, y, k1=self.prev_f[0]), f0
+            return rk4_alt_step_func(func, t0, dt, t1, y0, f0=self.prev_f[0], perturb=self.perturb), f0
         else:
             # Adams-Bashforth predictor.
             bashforth_coeffs = self.bashforth[order]
-            dy = _dot_product(dt * bashforth_coeffs, self.prev_f).type_as(y)  # bashforth is float64 so cast back
+            dy = _dot_product(dt * bashforth_coeffs, self.prev_f).type_as(y0)  # bashforth is float64 so cast back
 
             # Adams-Moulton corrector.
             if self.implicit:
                 moulton_coeffs = self.moulton[order + 1]
-                delta = dt * _dot_product(moulton_coeffs[1:], self.prev_f).type_as(y)  # moulton is float64 so cast back
+                delta = dt * _dot_product(moulton_coeffs[1:], self.prev_f).type_as(y0)  # moulton is float64 so cast back
                 converged = False
                 for _ in range(self.max_iters):
                     dy_old = dy
-                    f = func(t + dt, y + dy)
-                    dy = (dt * (moulton_coeffs[0]) * f).type_as(y) + delta  # moulton is float64 so cast back
+                    f = func(t1, y0 + dy, perturb=False if self.perturb else None)
+                    dy = (dt * (moulton_coeffs[0]) * f).type_as(y0) + delta  # moulton is float64 so cast back
                     converged = self._has_converged(dy_old, dy)
                     if converged:
                         break
                 if not converged:
                     warnings.warn('Functional iteration did not converge. Solution may be incorrect.', file=sys.stderr)
                     self.prev_f.pop()
-                self._update_history(t, f)
+                self._update_history(t0, f)
             return dy, f0
 
 

--- a/torchdiffeq/_impl/fixed_grid.py
+++ b/torchdiffeq/_impl/fixed_grid.py
@@ -1,12 +1,13 @@
 from .solvers import FixedGridODESolver
 from .rk_common import rk4_alt_step_func
+from .misc import Perturb
 
 
 class Euler(FixedGridODESolver):
     order = 1
 
     def _step_func(self, func, t0, dt, t1, y0):
-        f0 = func(t0, y0, perturb=True if self.perturb else None)
+        f0 = func(t0, y0, perturb=Perturb.NEXT if self.perturb else Perturb.NONE)
         return dt * f0, f0
 
 
@@ -15,7 +16,7 @@ class Midpoint(FixedGridODESolver):
 
     def _step_func(self, func, t0, dt, t1, y0):
         half_dt = 0.5 * dt
-        f0 = func(t0, y0, perturb=True if self.perturb else None)
+        f0 = func(t0, y0, perturb=Perturb.NEXT if self.perturb else Perturb.NONE)
         y_mid = y0 + f0 * half_dt
         return dt * func(t0 + half_dt, y_mid), f0
 
@@ -24,5 +25,5 @@ class RK4(FixedGridODESolver):
     order = 4
 
     def _step_func(self, func, t0, dt, t1, y0):
-        f0 = func(t0, y0, perturb=True if self.perturb else None)
+        f0 = func(t0, y0, perturb=Perturb.NEXT if self.perturb else Perturb.NONE)
         return rk4_alt_step_func(func, t0, dt, t1, y0, f0=f0, perturb=self.perturb), f0

--- a/torchdiffeq/_impl/fixed_grid.py
+++ b/torchdiffeq/_impl/fixed_grid.py
@@ -1,4 +1,3 @@
-import torch
 from .solvers import FixedGridODESolver
 from .rk_common import rk4_alt_step_func
 
@@ -6,36 +5,24 @@ from .rk_common import rk4_alt_step_func
 class Euler(FixedGridODESolver):
     order = 1
 
-    def __init__(self, eps=0., **kwargs):
-        super(Euler, self).__init__(**kwargs)
-        self.eps = torch.as_tensor(eps, dtype=self.dtype, device=self.device)
-
-    def _step_func(self, func, t, dt, y):
-        f0 = func(t + self.eps, y)
+    def _step_func(self, func, t0, dt, t1, y0):
+        f0 = func(t0, y0, perturb=True if self.perturb else None)
         return dt * f0, f0
 
 
 class Midpoint(FixedGridODESolver):
     order = 2
 
-    def __init__(self, eps=0., **kwargs):
-        super(Midpoint, self).__init__(**kwargs)
-        self.eps = torch.as_tensor(eps, dtype=self.dtype, device=self.device)
-
-    def _step_func(self, func, t, dt, y):
+    def _step_func(self, func, t0, dt, t1, y0):
         half_dt = 0.5 * dt
-        f0 = func(t + self.eps, y)
-        y_mid = y + f0 * half_dt
-        return dt * func(t + half_dt, y_mid), f0
+        f0 = func(t0, y0, perturb=True if self.perturb else None)
+        y_mid = y0 + f0 * half_dt
+        return dt * func(t0 + half_dt, y_mid), f0
 
 
 class RK4(FixedGridODESolver):
     order = 4
 
-    def __init__(self, eps=0., **kwargs):
-        super(RK4, self).__init__(**kwargs)
-        self.eps = torch.as_tensor(eps, dtype=self.dtype, device=self.device)
-
-    def _step_func(self, func, t, dt, y):
-        f0 = func(t + self.eps, y)
-        return rk4_alt_step_func(func, t + self.eps, dt - 2 * self.eps, y, k1=f0), f0
+    def _step_func(self, func, t0, dt, t1, y0):
+        f0 = func(t0, y0, perturb=True if self.perturb else None)
+        return rk4_alt_step_func(func, t0, dt, t1, y0, f0=f0, perturb=self.perturb), f0

--- a/torchdiffeq/_impl/misc.py
+++ b/torchdiffeq/_impl/misc.py
@@ -186,6 +186,9 @@ class _PerturbFunc(torch.nn.Module):
         self.base_func = base_func
 
     def forward(self, t, y, *, perturb=None):
+        # This dtype change here might be buggy.
+        # The exact time value should be determined inside the solver,
+        # but this can slightly change it due to numerical differences during casting.
         t = t.to(y.dtype)
         if perturb is True:
             t = _nextafter(t, self._inf)

--- a/torchdiffeq/_impl/misc.py
+++ b/torchdiffeq/_impl/misc.py
@@ -244,7 +244,11 @@ def _check_inputs(func, y0, t, rtol, atol, method, options, event_fn, SOLVERS):
         t_is_reversed = True
 
     if t_is_reversed:
+        # Change the integration times to ascending order.
+        # We do this by negating the time values and all associated arguments.
         t = -t
+
+        # Ensure time values are un-negated when calling functions.
         func = _ReverseFunc(func, mul=-1.0)
         if event_fn is not None:
             event_fn = _ReverseFunc(event_fn)

--- a/torchdiffeq/_impl/odeint.py
+++ b/torchdiffeq/_impl/odeint.py
@@ -64,7 +64,7 @@ def odeint(func, y0, t, *, rtol=1e-7, atol=1e-9, method=None, options=None, even
         ValueError: if an invalid `method` is provided.
     """
 
-    shapes, func, y0, t, rtol, atol, method, options, event_fn, decreasing_time = _check_inputs(func, y0, t, rtol, atol, method, options, event_fn, SOLVERS)
+    shapes, func, y0, t, rtol, atol, method, options, event_fn, t_is_reversed = _check_inputs(func, y0, t, rtol, atol, method, options, event_fn, SOLVERS)
 
     solver = SOLVERS[method](func=func, y0=y0, rtol=rtol, atol=atol, **options)
 
@@ -73,7 +73,7 @@ def odeint(func, y0, t, *, rtol=1e-7, atol=1e-9, method=None, options=None, even
     else:
         event_t, solution = solver.integrate_until_event(t[0], event_fn)
         event_t = event_t.to(t)
-        if decreasing_time:
+        if t_is_reversed:
             event_t = -event_t
 
     if shapes is not None:

--- a/torchdiffeq/_impl/rk_common.py
+++ b/torchdiffeq/_impl/rk_common.py
@@ -92,23 +92,25 @@ _two_thirds = 2 / 3
 _one_sixth = 1 / 6
 
 
-def rk4_step_func(func, t, dt, y, k1=None):
+def rk4_step_func(func, t0, dt, t1, y0, f0=None, perturb=False):
+    k1 = f0
     if k1 is None:
-        k1 = func(t, y)
+        k1 = func(t0, y0, perturb=True if perturb else None)
     half_dt = dt * 0.5
-    k2 = func(t + half_dt, y + half_dt * k1)
-    k3 = func(t + half_dt, y + half_dt * k2)
-    k4 = func(t + dt, y + dt * k3)
+    k2 = func(t0 + half_dt, y0 + half_dt * k1)
+    k3 = func(t0 + half_dt, y0 + half_dt * k2)
+    k4 = func(t1, y0 + dt * k3, perturb=False if perturb else None)
     return (k1 + 2 * (k2 + k3) + k4) * dt * _one_sixth
 
 
-def rk4_alt_step_func(func, t, dt, y, k1=None):
+def rk4_alt_step_func(func, t0, dt, t1, y0, f0=None, perturb=False):
     """Smaller error with slightly more compute."""
+    k1 = f0
     if k1 is None:
-        k1 = func(t, y)
-    k2 = func(t + dt * _one_third, y + dt * k1 * _one_third)
-    k3 = func(t + dt * _two_thirds, y + dt * (k2 - k1 * _one_third))
-    k4 = func(t + dt, y + dt * (k1 - k2 + k3))
+        k1 = func(t0, y0, perturb=True if perturb else None)
+    k2 = func(t0 + dt * _one_third, y0 + dt * k1 * _one_third)
+    k3 = func(t0 + dt * _two_thirds, y0 + dt * (k2 - k1 * _one_third))
+    k4 = func(t1, y0 + dt * (k1 - k2 + k3), perturb=False if perturb else None)
     return (k1 + 3 * (k2 + k3) + k4) * dt * 0.125
 
 


### PR DESCRIPTION
@patrick-kidger I'm breaking down your large patch (#134) into smaller ones, to merge them into master. This one includes refactoring of jumps. I should have gotten all of the related changes you made, and included some improvements:
 - Implement perturb for adams solvers.
 - Allow step_t and jump_t to be arbitrary (possibly unordered) tensors. This removes the need for extra handling outside of solver internals (e.g. flipping them in adjoint).

I removed `grid_points` and `eps` entirely. Going to increment the version number before this hits pypi anyway.

Let me know if this looks good to you. Also, feel free to resubmit a PR if you want to author these changes; wasn't sure how to break your PR properly while keeping your contributions.