### PR TITLE
Seminorm patch

### DIFF
--- a/FURTHER_DOCUMENTATION.md
+++ b/FURTHER_DOCUMENTATION.md
@@ -19,7 +19,7 @@ For these solvers, `rtol` and `atol` correspond to the tolerances for accepting/
 
 - `jump_t=None`: Times that a step must be made to, and `func` re-evaluated at. In particular this is useful when `func` has discontinuites at these times, as then the solver knows that the final function evaluation of the previous step is not equal to the first function evaluation of this step. (i.e. the FSAL property does not hold at this point.) If passed this should be a `torch.Tensor`. Note that this may not be efficient when using PyTorch 1.6.0 or earlier.
 
-- `norm`: What norm to compute the accept/reject criterion with respect to. Given tensor input, this defaults to an RMS norm. Given tupled input, it computes an RMS norm over each tensor, and then takes a max over the tuple, producing a mixed L-infinity/RMS norm. If passed this should be a function consuming a single tensor of shape the same as `y0` (given tensor input) or a single tensor of shape `(sum(y.numel() for y in y0),)` (given tupled input), and return a scalar tensor corresponding to its norm.
+- `norm`: What norm to compute the accept/reject criterion with respect to. Given tensor input, this defaults to an RMS norm. Given tupled input, this defaults to computing an RMS norm over each tensor, and then taking a max over the tuple, producing a mixed L-infinity/RMS norm. If passed this should be a function consuming a tensor/tuple with the same shape as `y0`, and return a scalar corresponding to its norm. When passed as part of `adjoint_options`, then the special value `"seminorm"` may be used to zero out the contribution from the parameters, as per the ["Hey, that's not an ODE"](https://arxiv.org/abs/2009.09457) paper.
 
 **Fixed solvers (euler, midpoint, rk4, explicit_adams, implicit_adams):**<br>
 
@@ -51,6 +51,8 @@ For this solver, `rtol` and `atol` correspond to the tolerance for convergence o
  The function `odeint_adjoint` offers some adjoint-specific options.
 
  - `adjoint_rtol`,<br>`adjoint_atol`,<br>`adjoint_method`,<br>`adjoint_options`:<br>The `rtol, atol, method, options` to use for the backward pass. Defaults to the values used for the forward pass.
+
+ - `adjoint_options` has the special key-value pair `{"norm": "seminorm"}` that provides a more efficient adjoint solve when using adaptive step solvers, as described in the ["Hey, that's not an ODE"](https://arxiv.org/abs/2009.09457) paper.
 
  - `adjoint_params`: The parameters to compute gradients with respect to in the backward pass. Should be a tuple of tensors. Defaults to `tuple(func.parameters())`.
    - If passed then `func` does not have to be a `torch.nn.Module`.

--- a/tests/norm_tests.py
+++ b/tests/norm_tests.py
@@ -288,3 +288,7 @@ class TestNorms(unittest.TestCase):
                         out.sum().backward()
 
                         self.assertLessEqual(seminorm_f.nfe, norm_f.nfe)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/norm_tests.py
+++ b/tests/norm_tests.py
@@ -1,0 +1,290 @@
+import unittest
+
+import torch
+import torchdiffeq
+
+from problems import (DTYPES, DEVICES, ADAPTIVE_METHODS)
+
+
+class _NeuralF(torch.nn.Module):
+    def __init__(self, width, oscillate):
+        super(_NeuralF, self).__init__()
+        self.linears = torch.nn.Sequential(torch.nn.Linear(2, width),
+                                           torch.nn.Tanh(),
+                                           torch.nn.Linear(width, 2),
+                                           torch.nn.Tanh())
+        self.nfe = 0
+        self.oscillate = oscillate
+
+    def forward(self, t, x):
+        self.nfe += 1
+        out = self.linears(x)
+        if self.oscillate:
+            out = out * t.mul(20).sin()
+        return out
+
+
+class TestNorms(unittest.TestCase):
+    def test_norm(self):
+        def f(t, x):
+            return x
+        t = torch.tensor([0., 1.])
+
+        # First test that tensor input appears in the norm.
+        is_called = False
+
+        def norm(state):
+            nonlocal is_called
+            is_called = True
+            self.assertIsInstance(state, torch.Tensor)
+            self.assertEqual(state.shape, ())
+            return state.pow(2).mean().sqrt()
+        x0 = torch.tensor(1.)
+        torchdiffeq.odeint(f, x0, t, options=dict(norm=norm))
+        self.assertTrue(is_called)
+
+        # Now test that tupled input appears in the norm
+        is_called = False
+
+        def norm(state):
+            nonlocal is_called
+            is_called = True
+            self.assertIsInstance(state, tuple)
+            self.assertEqual(len(state), 1)
+            state, = state
+            self.assertEqual(state.shape, ())
+            return state.pow(2).mean().sqrt()
+        x0 = (torch.tensor(1.),)
+        torchdiffeq.odeint(f, x0, t, options=dict(norm=norm))
+        self.assertTrue(is_called)
+
+        is_called = False
+
+        def norm(state):
+            nonlocal is_called
+            is_called = True
+            self.assertIsInstance(state, tuple)
+            self.assertEqual(len(state), 2)
+            state1, state2 = state
+            self.assertEqual(state1.shape, ())
+            self.assertEqual(state2.shape, (2, 2))
+            return state1.pow(2).mean().sqrt()
+        x0 = (torch.tensor(1.), torch.tensor([[0.5, 0.5], [0.1, 0.1]]))
+        torchdiffeq.odeint(f, x0, t, options=dict(norm=norm))
+        self.assertTrue(is_called)
+
+    def test_adjoint_norm(self):
+        def f(t, x):
+            return x
+        t = torch.tensor([0., 1.])
+        adjoint_params = (torch.rand(7, requires_grad=True), torch.rand((), requires_grad=True))
+
+        def make_spy_on_adjoint_norm(adjoint_norm, actual_norm):
+            is_spy_called = [False]
+
+            def spy_on_adjoint_norm(tensor):
+                nonlocal is_spy_called
+                is_spy_called[0] = True
+                norm_result = adjoint_norm(tensor)
+                true_norm_result = actual_norm(tensor)
+                self.assertIsInstance(norm_result, torch.Tensor)
+                self.assertEqual(norm_result.shape, true_norm_result.shape)
+                self.assertLess((norm_result - true_norm_result).abs().max(), 1e-6)
+                return norm_result
+
+            return spy_on_adjoint_norm, is_spy_called
+
+        # Test the various auto-constructed adjoint norms with tensor (not tuple) state
+        for shape in ((), (1,), (2, 2)):
+            for use_adjoint_options, seminorm in ((False, False), (True, False), (True, True)):
+                with self.subTest(shape=shape, use_adjoint_options=use_adjoint_options, seminorm=seminorm):
+                    x0 = torch.full(shape, 1.)
+                    if use_adjoint_options:
+                        if seminorm:
+                            # Test passing adjoint_options and wanting the seminorm
+                            kwargs = dict(adjoint_options=dict(norm='seminorm'))
+                        else:
+                            # Test passing adjoint_options but not specify the adjoint norm
+                            kwargs = dict(adjoint_options={})
+                    else:
+                        # Test not passing adjoint_options at all.
+                        kwargs = {}
+                    xs = torchdiffeq.odeint_adjoint(f, x0, t, adjoint_params=adjoint_params, **kwargs)
+                    _adjoint_norm = xs.grad_fn.adjoint_options['norm']
+
+                    is_called = False
+
+                    def actual_norm(tensor_tuple):
+                        nonlocal is_called
+                        is_called = True
+                        self.assertIsInstance(tensor_tuple, tuple)
+                        t, y, adj_y, adj_param1, adj_param2 = tensor_tuple
+                        self.assertEqual(t.shape, ())
+                        self.assertEqual(y.shape, shape)
+                        self.assertEqual(adj_y.shape, shape)
+                        self.assertEqual(adj_param1.shape, (7,))
+                        self.assertEqual(adj_param2.shape, (()))
+                        out = max(t.abs(), y.pow(2).mean().sqrt(), adj_y.pow(2).mean().sqrt())
+                        if not seminorm:
+                            out = max(out, adj_param1.pow(2).mean().sqrt(), adj_param2.abs())
+                        return out
+
+                    xs.grad_fn.adjoint_options['norm'], is_spy_called = make_spy_on_adjoint_norm(_adjoint_norm,
+                                                                                                 actual_norm)
+                    xs.sum().backward()
+                    self.assertTrue(is_called)
+                    self.assertTrue(is_spy_called[0])
+
+        # Test the various auto-constructed adjoint norms with tuple (not tensor) state
+        for use_adjoint_options, seminorm in ((False, False), (True, False), (True, True)):
+            with self.subTest(shape=shape, use_adjoint_options=use_adjoint_options, seminorm=seminorm):
+                x0 = torch.tensor(1.), torch.tensor([[0.5, 0.5], [0.1, 0.1]])
+                if use_adjoint_options:
+                    if seminorm:
+                        # Test passing adjoint_options and wanting the seminorm
+                        kwargs = dict(adjoint_options=dict(norm='seminorm'))
+                    else:
+                        # Test passing adjoint_options but not specify the adjoint norm
+                        kwargs = dict(adjoint_options={})
+                else:
+                    # Test not passing adjoint_options at all.
+                    kwargs = {}
+                xs = torchdiffeq.odeint_adjoint(f, x0, t, adjoint_params=adjoint_params, **kwargs)
+                adjoint_options_dict = xs[0].grad_fn.next_functions[0][0].next_functions[0][0].adjoint_options
+                _adjoint_norm = adjoint_options_dict['norm']
+
+                is_called = False
+
+                def actual_norm(tensor_tuple):
+                    nonlocal is_called
+                    is_called = True
+                    self.assertIsInstance(tensor_tuple, tuple)
+                    t, y, adj_y, adj_param1, adj_param2 = tensor_tuple
+                    self.assertEqual(t.shape, ())
+                    self.assertEqual(y.shape, (5,))
+                    self.assertEqual(adj_y.shape, (5,))
+                    self.assertEqual(adj_param1.shape, (7,))
+                    self.assertEqual(adj_param2.shape, ())
+                    ya = y[0]
+                    yb = y[1:]
+                    adj_ya = adj_y[0]
+                    adj_yb = adj_y[1:4]
+                    out = max(t.abs(), ya.abs(), yb.pow(2).mean().sqrt(), adj_ya.abs(), adj_yb.pow(2).mean().sqrt())
+                    if not seminorm:
+                        out = max(out, adj_param1.pow(2).mean().sqrt(), adj_param2.abs())
+                    return out
+
+                spy_on_adjoint_norm, is_spy_called = make_spy_on_adjoint_norm(_adjoint_norm, actual_norm)
+                adjoint_options_dict['norm'] = spy_on_adjoint_norm
+                xs[0].sum().backward()
+                self.assertTrue(is_called)
+                self.assertTrue(is_spy_called[0])
+
+        # Test user-passed adjoint norms with tensor (not tuple) state
+        is_called = False
+
+        def adjoint_norm(tensor_tuple):
+            nonlocal is_called
+            is_called = True
+            self.assertIsInstance(tensor_tuple, tuple)
+            t, y, adj_y, adj_param1, adj_param2 = tensor_tuple
+            self.assertEqual(t.shape, ())
+            self.assertEqual(y.shape, ())
+            self.assertEqual(adj_y.shape, ())
+            self.assertEqual(adj_param1.shape, (7,))
+            self.assertEqual(adj_param2.shape, ())
+            return max(t.abs(), y.pow(2).mean().sqrt(), adj_y.pow(2).mean().sqrt(), adj_param1.pow(2).mean().sqrt(),
+                       adj_param2.abs())
+
+        x0 = torch.tensor(1.)
+        xs = torchdiffeq.odeint_adjoint(f, x0, t, adjoint_params=adjoint_params,
+                                        adjoint_options=dict(norm=adjoint_norm))
+        xs.sum().backward()
+        self.assertTrue(is_called)
+
+        # Test user-passed adjoint norms with tuple (not tensor) state
+        is_called = False
+
+        def adjoint_norm(tensor_tuple):
+            nonlocal is_called
+            is_called = True
+            self.assertIsInstance(tensor_tuple, tuple)
+            t, ya, yb, adj_ya, adj_yb, adj_param1, adj_param2 = tensor_tuple
+            self.assertEqual(t.shape, ())
+            self.assertEqual(ya.shape, ())
+            self.assertEqual(yb.shape, (2, 2))
+            self.assertEqual(adj_ya.shape, ())
+            self.assertEqual(adj_yb.shape, (2, 2))
+            self.assertEqual(adj_param1.shape, (7,))
+            self.assertEqual(adj_param2.shape, ())
+            return max(t.abs(), ya.abs(), yb.pow(2).mean().sqrt(), adj_ya.abs(), adj_yb.pow(2).mean().sqrt(),
+                       adj_param1.pow(2).mean().sqrt(), adj_param2.abs())
+
+        x0 = torch.tensor(1.), torch.tensor([[0.5, 0.5], [0.1, 0.1]])
+        xs = torchdiffeq.odeint_adjoint(f, x0, t, adjoint_params=adjoint_params,
+                                        adjoint_options=dict(norm=adjoint_norm))
+        xs[0].sum().backward()
+        self.assertTrue(is_called)
+
+    def test_large_norm(self):
+        torch.manual_seed(3456789)  # test can be flaky
+
+        def norm(tensor):
+            return tensor.abs().max()
+
+        def large_norm(tensor):
+            return 10 * tensor.abs().max()
+
+        for dtype in DTYPES:
+            for device in DEVICES:
+                for method in ADAPTIVE_METHODS:
+                    if dtype == torch.float32 and method == 'dopri8':
+                        continue
+
+                    with self.subTest(dtype=dtype, device=device, method=method):
+                        x0 = torch.tensor([1.0, 2.0], device=device, dtype=dtype)
+                        t = torch.tensor([0., 1.0], device=device, dtype=dtype)
+
+                        norm_f = _NeuralF(width=10, oscillate=True).to(device, dtype)
+                        torchdiffeq.odeint(norm_f, x0, t, method=method, options=dict(norm=norm))
+                        large_norm_f = _NeuralF(width=10, oscillate=True).to(device, dtype)
+                        with torch.no_grad():
+                            for norm_param, large_norm_param in zip(norm_f.parameters(), large_norm_f.parameters()):
+                                large_norm_param.copy_(norm_param)
+                        torchdiffeq.odeint(large_norm_f, x0, t, method=method, options=dict(norm=large_norm))
+
+                        self.assertLessEqual(norm_f.nfe, large_norm_f.nfe)
+
+    def test_seminorm(self):
+        torch.manual_seed(3456786)  # test can be flaky
+        for dtype in DTYPES:
+            for device in DEVICES:
+                for method in ADAPTIVE_METHODS:
+                    if method == 'adaptive_heun':
+                        # Adaptive heun is consistently an awful choice with seminorms, it seems. My guess is that it's
+                        # consistently overconfident with its step sizes, and that having seminorms turned off means
+                        # that it actually gets it right more often.
+                        continue
+                    if dtype == torch.float32 and method == 'dopri8':
+                        continue
+
+                    with self.subTest(dtype=dtype, device=device, method=method):
+
+                        x0 = torch.tensor([1.0, 2.0], device=device, dtype=dtype)
+                        t = torch.tensor([0., 1.0], device=device, dtype=dtype)
+
+                        norm_f = _NeuralF(width=256, oscillate=True).to(device, dtype)
+                        out = torchdiffeq.odeint_adjoint(norm_f, x0, t, atol=3e-7, method=method)
+                        norm_f.nfe = 0
+                        out.sum().backward()
+
+                        seminorm_f = _NeuralF(width=256, oscillate=True).to(device, dtype)
+                        with torch.no_grad():
+                            for norm_param, seminorm_param in zip(norm_f.parameters(), seminorm_f.parameters()):
+                                seminorm_param.copy_(norm_param)
+                        out = torchdiffeq.odeint_adjoint(seminorm_f, x0, t, atol=1e-6, method=method,
+                                                         adjoint_options=dict(norm='seminorm'))
+                        seminorm_f.nfe = 0
+                        out.sum().backward()
+
+                        self.assertLessEqual(seminorm_f.nfe, norm_f.nfe)

--- a/tests/run_all.py
+++ b/tests/run_all.py
@@ -2,6 +2,7 @@ import unittest
 from api_tests import *
 from event_tests import *
 from gradient_tests import *
+from norm_tests import *
 from odeint_tests import *
 
 if __name__ == '__main__':

--- a/torchdiffeq/_impl/adjoint.py
+++ b/torchdiffeq/_impl/adjoint.py
@@ -1,7 +1,9 @@
+import warnings
 import torch
 import torch.nn as nn
 from .odeint import SOLVERS, odeint
-from .misc import _check_inputs, _flat_to_shape, _rms_norm, _mixed_linf_rms_norm, _wrap_norm
+from .misc import _check_inputs, _flat_to_shape
+from .misc import _mixed_norm
 
 
 class OdeintAdjointMethod(torch.autograd.Function):
@@ -34,7 +36,6 @@ class OdeintAdjointMethod(torch.autograd.Function):
     @staticmethod
     def backward(ctx, *grad_y):
         with torch.no_grad():
-            shapes = ctx.shapes
             func = ctx.func
             adjoint_rtol = ctx.adjoint_rtol
             adjoint_atol = ctx.adjoint_atol
@@ -55,27 +56,6 @@ class OdeintAdjointMethod(torch.autograd.Function):
                 grad_y = grad_y[1]
             else:
                 grad_y = grad_y[0]
-
-            ##################################
-            #     Set up adjoint_options     #
-            ##################################
-
-            if adjoint_options is None:
-                adjoint_options = {}
-            else:
-                adjoint_options = adjoint_options.copy()
-
-            # Backward compatibility: by default use a mixed L-infinity/RMS norm over the input, where we treat t, each
-            # element of y, and each element of adj_y separately over the Linf, but consider all the parameters
-            # together.
-            if 'norm' not in adjoint_options:
-                if shapes is None:
-                    shapes = [y[-1].shape]  # [-1] because y has shape (len(t), *y0.shape)
-                # adj_t, y, adj_y, adj_params, corresponding to the order in aug_state below
-                adjoint_shapes = [torch.Size(())] + shapes + shapes + [torch.Size([sum(param.numel()
-                                                                                       for param in adjoint_params)])]
-                adjoint_options['norm'] = _mixed_linf_rms_norm(adjoint_shapes)
-            # ~Backward compatibility
 
             ##################################
             #      Set up initial state      #
@@ -108,9 +88,9 @@ class OdeintAdjointMethod(torch.autograd.Function):
                     func_eval = func(t if t_requires_grad else t_, y)
 
                     # Workaround for PyTorch bug #39784
-                    _t = torch.as_strided(t, (), ())
-                    _y = torch.as_strided(y, (), ())
-                    _params = tuple(torch.as_strided(param, (), ()) for param in adjoint_params)
+                    _t = torch.as_strided(t, (), ())  # noqa
+                    _y = torch.as_strided(y, (), ())  # noqa
+                    _params = tuple(torch.as_strided(param, (), ()) for param in adjoint_params)  # noqa
 
                     vjp_t, vjp_y, *vjp_params = torch.autograd.grad(
                         func_eval, (t, y) + adjoint_params, -adj_y,
@@ -182,22 +162,35 @@ def odeint_adjoint(func, y0, t, *, rtol=1e-7, atol=1e-9, method=None, options=No
         adjoint_atol = atol
     if adjoint_method is None:
         adjoint_method = method
+
     if adjoint_options is None:
         adjoint_options = {k: v for k, v in options.items() if k != "norm"} if options is not None else {}
+    else:
+        adjoint_options = adjoint_options.copy()
+
     if adjoint_params is None:
         adjoint_params = tuple(find_parameters(func))
     else:
         adjoint_params = tuple(adjoint_params)  # in case adjoint_params is a generator.
 
     # Filter params that don't require gradients.
+    for p in adjoint_params:
+        if not p.requires_grad:
+            # Issue a warning if a user-specified norm is specified.
+            if 'norm' in adjoint_options and adjoint_options['norm'] != 'seminorm':
+                warnings.warn("An adjoint parameter was passed without requiring gradient. For efficiency this will be "
+                              "excluded from the adjoint pass, and will not appear as a tensor in the adjoint norm.")
+
     adjoint_params = tuple(p for p in adjoint_params if p.requires_grad)
 
-    # Normalise to non-tupled input
+    # Normalise to non-tupled state.
     shapes, func, y0, t, rtol, atol, method, options, event_fn, decreasing_time = _check_inputs(func, y0, t, rtol, atol, method, options, event_fn, SOLVERS)
 
-    if "norm" in options and "norm" not in adjoint_options:
-        adjoint_shapes = [torch.Size(()), y0.shape, y0.shape] + [torch.Size([sum(param.numel() for param in adjoint_params)])]
-        adjoint_options["norm"] = _wrap_norm([_rms_norm, options["norm"], options["norm"]], adjoint_shapes)
+    # Avoid in-place modifying a user-specified dict.
+    adjoint_options = adjoint_options.copy()
+    # Handle the adjoint norm function.
+    state_norm = options["norm"]
+    handle_adjoint_norm_(adjoint_options, shapes, state_norm)
 
     ans = OdeintAdjointMethod.apply(shapes, func, y0, t, rtol, atol, method, options, event_fn, adjoint_rtol, adjoint_atol,
                                     adjoint_method, adjoint_options, t.requires_grad, *adjoint_params)
@@ -233,3 +226,51 @@ def find_parameters(module):
         return [param for _, param in gen]
     else:
         return list(module.parameters())
+
+
+def handle_adjoint_norm_(adjoint_options, shapes, state_norm):
+    """In-place modifies the adjoint options to choose or wrap the norm function."""
+
+    # This is the default adjoint norm on the backward pass: a mixed norm over the tuple of inputs.
+    def default_adjoint_norm(tensor_tuple):
+        t, y, adj_y, *adj_params = tensor_tuple
+        # (If the state is actually a flattened tuple then this will be unpacked again in state_norm.)
+        return max(t.abs(), state_norm(y), state_norm(adj_y), _mixed_norm(adj_params))
+
+    if "norm" not in adjoint_options:
+        # `adjoint_options` was not explicitly specified by the user. Use the default norm.
+        adjoint_options["norm"] = default_adjoint_norm
+    else:
+        # `adjoint_options` was explicitly specified by the user...
+        try:
+            adjoint_norm = adjoint_options['norm']
+        except KeyError:
+            # ...but they did not specify the norm argument. Back to plan A: use the default norm.
+            adjoint_options['norm'] = default_adjoint_norm
+        else:
+            # ...and they did specify the norm argument.
+            if adjoint_norm == 'seminorm':
+                # They told us they want to use seminorms. Slight modification to plan A: use the default norm,
+                # but ignore the parameter state
+                def adjoint_seminorm(tensor_tuple):
+                    t, y, adj_y, *adj_params = tensor_tuple
+                    # (If the state is actually a flattened tuple then this will be unpacked again in state_norm.)
+                    return max(t.abs(), state_norm(y), state_norm(adj_y))
+                adjoint_options['norm'] = adjoint_seminorm
+            else:
+                # And they're using their own custom norm.
+                if shapes is None:
+                    # The state on the forward pass was a tensor, not a tuple. We don't need to do anything, they're
+                    # already going to get given the full adjoint state as (t, y, adj_y, adj_params)
+                    pass  # this branch included for clarity
+                else:
+                    # This is the bit that is tuple/tensor abstraction-breaking, because the odeint machinery
+                    # doesn't know about the tupled nature of the forward state. We need to tell the user's adjoint
+                    # norm about that ourselves.
+
+                    def _adjoint_norm(tensor_tuple):
+                        t, y, adj_y, *adj_params = tensor_tuple
+                        y = _flat_to_shape(y, (), shapes)
+                        adj_y = _flat_to_shape(adj_y, (), shapes)
+                        return adjoint_norm((t, *y, *adj_y, *adj_params))
+                    adjoint_options['norm'] = _adjoint_norm


### PR DESCRIPTION
This patch contains parts of the PR that @patrick-kidger wrote for updating the norm and seminorm API. I really like the extensive test you wrote!

This contains:
 - a refactoring of the norm api to take a function of tuples instead of the flattened tensor, when the state is a tuple. 
 - "seminorm" shortcut option.

@patrick-kidger Can you take a quick look?