### PR TITLE
Enabled min_step, max_step args for adaptive solvers

### DIFF
--- a/tests/odeint_tests.py
+++ b/tests/odeint_tests.py
@@ -240,5 +240,4 @@ class TestMinMaxStep(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    TestMinMaxStep().test_min_max_step()
-    # unittest.main()
+    unittest.main()

--- a/tests/problems.py
+++ b/tests/problems.py
@@ -38,8 +38,10 @@ class LinearODE(torch.nn.Module):
         A = 2 * U - (U + U.transpose(0, 1))
         self.A = torch.nn.Parameter(A)
         self.initial_val = np.ones((dim, 1))
+        self.nfe = 0
 
     def forward(self, t, y):
+        self.nfe += 1
         return torch.mm(self.A, y.reshape(self.dim, 1)).reshape(-1)
 
     def y_exact(self, t):

--- a/torchdiffeq/_impl/scipy_wrapper.py
+++ b/torchdiffeq/_impl/scipy_wrapper.py
@@ -6,7 +6,7 @@ from .misc import _handle_unused_kwargs
 
 class ScipyWrapperODESolver(metaclass=abc.ABCMeta):
 
-    def __init__(self, func, y0, rtol, atol, solver="LSODA", **unused_kwargs):
+    def __init__(self, func, y0, rtol, atol, min_step=0, max_step=float('inf'), solver="LSODA", **unused_kwargs):
         unused_kwargs.pop('norm', None)
         unused_kwargs.pop('grid_points', None)
         unused_kwargs.pop('eps', None)
@@ -19,6 +19,8 @@ class ScipyWrapperODESolver(metaclass=abc.ABCMeta):
         self.y0 = y0.detach().cpu().numpy().reshape(-1)
         self.rtol = rtol
         self.atol = atol
+        self.min_step = min_step
+        self.max_step = max_step
         self.solver = solver
         self.func = convert_func_to_numpy(func, self.shape, self.device, self.dtype)
 
@@ -34,6 +36,8 @@ class ScipyWrapperODESolver(metaclass=abc.ABCMeta):
             method=self.solver,
             rtol=self.rtol,
             atol=self.atol,
+            min_step=self.min_step,
+            max_step=self.max_step
         )
         sol = torch.tensor(sol.y).T.to(self.device, self.dtype)
         sol = sol.reshape(-1, *self.shape)


### PR DESCRIPTION
Added `min_step` and `max_step` arguments for `RKAdaptiveStepsizeODESolver` to mimic the arguments in `ScipyWrapperODESolver`. Any step is rejected if `> max_step` and accepted if `< min_step` with the next step being clamped between `[min_step, max_step]`. 

