### PR TITLE
Manually reject step from ODE function with adaptive step solvers

### DIFF
--- a/torchdiffeq/__init__.py
+++ b/torchdiffeq/__init__.py
@@ -1,4 +1,5 @@
 from ._impl import odeint
 from ._impl import odeint_adjoint
 from ._impl import odeint_event
+from ._impl import RejectStepError
 __version__ = "0.2.3"

--- a/torchdiffeq/_impl/__init__.py
+++ b/torchdiffeq/_impl/__init__.py
@@ -1,2 +1,3 @@
 from .odeint import odeint, odeint_event
 from .adjoint import odeint_adjoint
+from .rk_common import RejectStepError

--- a/torchdiffeq/_impl/rk_common.py
+++ b/torchdiffeq/_impl/rk_common.py
@@ -273,8 +273,12 @@ class RKAdaptiveStepsizeODESolver(AdaptiveStepsizeEventODESolver):
             # f1.dtype == self.y0.dtype
             # y1_error.dtype == self.dtype
             # k.dtype == self.y0.dtype
-        except RejectStepError:
+        except RejectStepError as ex:
             # self.func requested the step be rejected
+            # If already at minimum step size, stop integration as can't proceed
+            if dt <= self.min_step:
+                raise(ex)
+            error_ratio = torch.tensor(10.0, dtype=self.dtype, device=self.y0.device)
             accept_step = False
         else:
             ########################################################


### PR DESCRIPTION
For some ODE functions, there are certain feasible regions of state values, and states outside this region result in undefined derivatives. In this situation, it is helpful to be able to communicate to an adaptive solver that it should try a smaller step instead.

This PR adds a `RejectStepError` exception class that can be raised by an ODE function. If this happens, an adaptive step solver will reject the step and reduce the step size. If the step size is already at the minimum, the exception will be re-raised to avoid an infinite loop.

I've fixed the error ratio to 10 for the new step size calculation, but open to other ideas as this is somewhat arbitrary.

If you think this contribution is worth merging, I can add some documentation and tests.