### PR TITLE
Proposal: Adding additional explicit solvers

### DIFF
--- a/torchdiffeq/_impl/fixed_grid.py
+++ b/torchdiffeq/_impl/fixed_grid.py
@@ -1,5 +1,5 @@
 from .solvers import FixedGridODESolver
-from .rk_common import rk4_alt_step_func
+from .rk_common import rk4_step_func, rk4_alt_step_func
 from .misc import Perturb
 
 
@@ -9,6 +9,16 @@ class Euler(FixedGridODESolver):
     def _step_func(self, func, t0, dt, t1, y0):
         f0 = func(t0, y0, perturb=Perturb.NEXT if self.perturb else Perturb.NONE)
         return dt * f0, f0
+
+
+class Heun(FixedGridODESolver):
+    order = 2
+
+    def _step_func(self, func, t0, dt, t1, y0):
+        half_dt = 0.5 * dt
+        f0 = func(t0, y0, perturb=Perturb.NEXT if self.perturb else Perturb.NONE)
+        f1 = func(t0 + dt, y0 + dt * f0)
+        return half_dt * (f0 + f1), f0
 
 
 class Midpoint(FixedGridODESolver):
@@ -21,9 +31,53 @@ class Midpoint(FixedGridODESolver):
         return dt * func(t0 + half_dt, y_mid), f0
 
 
+class Ralston(FixedGridODESolver):
+    order = 2
+
+    def _step_func(self, func, t0, dt, t1, y0):
+        fourth_dt = 0.25 * dt
+        double_dt = 2 * dt
+        f0 = func(t0, y0, perturb=Perturb.NEXT if self.perturb else Perturb.NONE)
+        f1 = func(t0 + double_dt / 3, y0 + double_dt * f0 / 3)
+        return fourth_dt * (f0 + 3 * f1), f0
+
+
+class RK3(FixedGridODESolver):
+    order = 3
+
+    def _step_func(self, func, t0, dt, t1, y0):
+        half_dt = 0.5 * dt
+        double_dt = 2 * dt
+        sixth_dt = (1 / 6) * dt
+        f0 = func(t0, y0, perturb=Perturb.NEXT if self.perturb else Perturb.NONE)
+        f1 = func(t0 + half_dt, y0 + half_dt * f0)
+        f2 = func(t0 + dt, y0 - dt * f0 + double_dt * f1)
+        return sixth_dt * (f0 + 4 * f1 + f2), f0
+
+
+class SSPRK3(FixedGridODESolver):
+    order = 3
+
+    def _step_func(self, func, t0, dt, t1, y0):
+        fourth_dt = 0.25 * dt
+        sixth_dt = (1 / 6) * dt
+        f0 = func(t0, y0, perturb=Perturb.NEXT if self.perturb else Perturb.NONE)
+        f1 = func(t0 + dt, y0 + dt * f0)
+        f2 = func(t0 + fourth_dt, y0 + fourth_dt * (f0 + f1))
+        return sixth_dt * (f0 + f1 + 4 * f2), f0
+
+
 class RK4(FixedGridODESolver):
     order = 4
 
     def _step_func(self, func, t0, dt, t1, y0):
         f0 = func(t0, y0, perturb=Perturb.NEXT if self.perturb else Perturb.NONE)
         return rk4_alt_step_func(func, t0, dt, t1, y0, f0=f0, perturb=self.perturb), f0
+
+
+class ClassicRK4(FixedGridODESolver):
+    order = 4
+
+    def _step_func(self, func, t0, dt, t1, y0):
+        f0 = func(t0, y0, perturb=Perturb.NEXT if self.perturb else Perturb.NONE)
+        return rk4_step_func(func, t0, dt, t1, y0, f0=f0, perturb=self.perturb), f0

--- a/torchdiffeq/_impl/odeint.py
+++ b/torchdiffeq/_impl/odeint.py
@@ -4,7 +4,7 @@ from .dopri5 import Dopri5Solver
 from .bosh3 import Bosh3Solver
 from .adaptive_heun import AdaptiveHeunSolver
 from .fehlberg2 import Fehlberg2
-from .fixed_grid import Euler, Midpoint, RK4
+from .fixed_grid import Euler, Heun, Midpoint, Ralston, RK3, SSPRK3, ClassicRK4, RK4
 from .fixed_adams import AdamsBashforth, AdamsBashforthMoulton
 from .dopri8 import Dopri8Solver
 from .scipy_wrapper import ScipyWrapperODESolver
@@ -17,7 +17,12 @@ SOLVERS = {
     'fehlberg2': Fehlberg2,
     'adaptive_heun': AdaptiveHeunSolver,
     'euler': Euler,
+    'heun': Heun,
     'midpoint': Midpoint,
+    'ralston': Ralston,
+    'rk3': RK3,
+    'ssprk3': SSPRK3,
+    'crk4': ClassicRK4,
     'rk4': RK4,
     'explicit_adams': AdamsBashforth,
     'implicit_adams': AdamsBashforthMoulton,


### PR DESCRIPTION
For the purpose of my own research, I have implemented explicit solvers that I thought could be of interest to other users. I especially thought that the addition of a third-order integration method would nicely complement the pre-existing solver library. 
I have forked the repo and briefly added some classics to illustrate potential additions, but I am open to discussion on which should be added; perhaps, even more than what I have added are of interest (flavors of second/third/fourth-order methods) c.f. https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods. 