### PR TITLE
Set default dtype

### DIFF
--- a/tests/norm_tests.py
+++ b/tests/norm_tests.py
@@ -257,7 +257,7 @@ class TestNorms(unittest.TestCase):
 
                     with self.subTest(dtype=dtype, device=device, method=method):
                         x0 = torch.tensor([1.0, 2.0], device=device, dtype=dtype)
-                        t = torch.tensor([0., 1.0], device=device, dtype=torch.float64)
+                        t = torch.tensor([0., 1.0], device=device, dtype=torch.get_default_dtype())
 
                         norm_f = _NeuralF(width=10, oscillate=True).to(device, dtype)
                         torchdiffeq.odeint(norm_f, x0, t, method=method, options=dict(norm=norm))
@@ -282,7 +282,7 @@ class TestNorms(unittest.TestCase):
                             tol = 1e-6
 
                         x0 = torch.tensor([1.0, 2.0], device=device, dtype=dtype)
-                        t = torch.tensor([0., 1.0], device=device, dtype=torch.float64)
+                        t = torch.tensor([0., 1.0], device=device, dtype=torch.get_default_dtype())
 
                         ode_f = _NeuralF(width=1024, oscillate=True).to(device, dtype)
 

--- a/tests/problems.py
+++ b/tests/problems.py
@@ -65,11 +65,20 @@ SCIPY_METHODS = ('scipy_solver',)
 METHODS = FIXED_METHODS + ADAPTIVE_METHODS + SCIPY_METHODS
 
 
-def construct_problem(device, npts=10, ode='constant', reverse=False, dtype=torch.float64):
+def construct_problem(device,
+                      npts=10,
+                      ode='constant',
+                      reverse=False,
+                      dtype=torch.get_default_dtype()):
 
     f = PROBLEMS[ode]().to(dtype=dtype, device=device)
 
-    t_points = torch.linspace(1, 8, npts, dtype=torch.float64, device=device, requires_grad=True)
+    t_points = torch.linspace(1,
+                              8,
+                              npts,
+                              dtype=torch.get_default_dtype(),
+                              device=device,
+                              requires_grad=True)
     sol = f.y_exact(t_points).to(dtype)
 
     def _flip(x, dim):

--- a/torchdiffeq/__init__.py
+++ b/torchdiffeq/__init__.py
@@ -1,3 +1,10 @@
+# Hack to allow for training on Mac (MPS) which supports only float32
+import torch
+if torch.backends.mps.is_available():
+    torch.set_default_dtype(torch.float32)
+else:
+    torch.set_default_dtype(torch.float64)
+
 from ._impl import odeint
 from ._impl import odeint_adjoint
 from ._impl import odeint_event

--- a/torchdiffeq/_impl/adaptive_heun.py
+++ b/torchdiffeq/_impl/adaptive_heun.py
@@ -3,20 +3,20 @@ from .rk_common import _ButcherTableau, RKAdaptiveStepsizeODESolver
 
 
 _ADAPTIVE_HEUN_TABLEAU = _ButcherTableau(
-    alpha=torch.tensor([1.], dtype=torch.float64),
+    alpha=torch.tensor([1.], dtype=torch.get_default_dtype()),
     beta=[
-        torch.tensor([1.], dtype=torch.float64),
+        torch.tensor([1.], dtype=torch.get_default_dtype()),
     ],
-    c_sol=torch.tensor([0.5, 0.5], dtype=torch.float64),
+    c_sol=torch.tensor([0.5, 0.5], dtype=torch.get_default_dtype()),
     c_error=torch.tensor([
         0.5,
         -0.5,
-    ], dtype=torch.float64),
+    ], dtype=torch.get_default_dtype()),
 )
 
 _AH_C_MID = torch.tensor([
     0.5, 0.
-], dtype=torch.float64)
+], dtype=torch.get_default_dtype())
 
 
 class AdaptiveHeunSolver(RKAdaptiveStepsizeODESolver):

--- a/torchdiffeq/_impl/bosh3.py
+++ b/torchdiffeq/_impl/bosh3.py
@@ -3,17 +3,20 @@ from .rk_common import _ButcherTableau, RKAdaptiveStepsizeODESolver
 
 
 _BOGACKI_SHAMPINE_TABLEAU = _ButcherTableau(
-    alpha=torch.tensor([1 / 2, 3 / 4, 1.], dtype=torch.float64),
+    alpha=torch.tensor([1 / 2, 3 / 4, 1.], dtype=torch.get_default_dtype()),
     beta=[
-        torch.tensor([1 / 2], dtype=torch.float64),
-        torch.tensor([0., 3 / 4], dtype=torch.float64),
-        torch.tensor([2 / 9, 1 / 3, 4 / 9], dtype=torch.float64)
+        torch.tensor([1 / 2], dtype=torch.get_default_dtype()),
+        torch.tensor([0., 3 / 4], dtype=torch.get_default_dtype()),
+        torch.tensor([2 / 9, 1 / 3, 4 / 9], dtype=torch.get_default_dtype())
     ],
-    c_sol=torch.tensor([2 / 9, 1 / 3, 4 / 9, 0.], dtype=torch.float64),
-    c_error=torch.tensor([2 / 9 - 7 / 24, 1 / 3 - 1 / 4, 4 / 9 - 1 / 3, -1 / 8], dtype=torch.float64),
+    c_sol=torch.tensor([2 / 9, 1 / 3, 4 / 9, 0.],
+                       dtype=torch.get_default_dtype()),
+    c_error=torch.tensor(
+        [2 / 9 - 7 / 24, 1 / 3 - 1 / 4, 4 / 9 - 1 / 3, -1 / 8],
+        dtype=torch.get_default_dtype()),
 )
 
-_BS_C_MID = torch.tensor([0., 0.5, 0., 0.], dtype=torch.float64)
+_BS_C_MID = torch.tensor([0., 0.5, 0., 0.], dtype=torch.get_default_dtype())
 
 
 class Bosh3Solver(RKAdaptiveStepsizeODESolver):

--- a/torchdiffeq/_impl/dopri5.py
+++ b/torchdiffeq/_impl/dopri5.py
@@ -3,16 +3,16 @@ from .rk_common import _ButcherTableau, RKAdaptiveStepsizeODESolver
 
 
 _DORMAND_PRINCE_SHAMPINE_TABLEAU = _ButcherTableau(
-    alpha=torch.tensor([1 / 5, 3 / 10, 4 / 5, 8 / 9, 1., 1.], dtype=torch.float64),
+    alpha=torch.tensor([1 / 5, 3 / 10, 4 / 5, 8 / 9, 1., 1.], dtype=torch.get_default_dtype()),
     beta=[
-        torch.tensor([1 / 5], dtype=torch.float64),
-        torch.tensor([3 / 40, 9 / 40], dtype=torch.float64),
-        torch.tensor([44 / 45, -56 / 15, 32 / 9], dtype=torch.float64),
-        torch.tensor([19372 / 6561, -25360 / 2187, 64448 / 6561, -212 / 729], dtype=torch.float64),
-        torch.tensor([9017 / 3168, -355 / 33, 46732 / 5247, 49 / 176, -5103 / 18656], dtype=torch.float64),
-        torch.tensor([35 / 384, 0, 500 / 1113, 125 / 192, -2187 / 6784, 11 / 84], dtype=torch.float64),
+        torch.tensor([1 / 5], dtype=torch.get_default_dtype()),
+        torch.tensor([3 / 40, 9 / 40], dtype=torch.get_default_dtype()),
+        torch.tensor([44 / 45, -56 / 15, 32 / 9], dtype=torch.get_default_dtype()),
+        torch.tensor([19372 / 6561, -25360 / 2187, 64448 / 6561, -212 / 729], dtype=torch.get_default_dtype()),
+        torch.tensor([9017 / 3168, -355 / 33, 46732 / 5247, 49 / 176, -5103 / 18656], dtype=torch.get_default_dtype()),
+        torch.tensor([35 / 384, 0, 500 / 1113, 125 / 192, -2187 / 6784, 11 / 84], dtype=torch.get_default_dtype()),
     ],
-    c_sol=torch.tensor([35 / 384, 0, 500 / 1113, 125 / 192, -2187 / 6784, 11 / 84, 0], dtype=torch.float64),
+    c_sol=torch.tensor([35 / 384, 0, 500 / 1113, 125 / 192, -2187 / 6784, 11 / 84, 0], dtype=torch.get_default_dtype()),
     c_error=torch.tensor([
         35 / 384 - 1951 / 21600,
         0,
@@ -21,13 +21,13 @@ _DORMAND_PRINCE_SHAMPINE_TABLEAU = _ButcherTableau(
         -2187 / 6784 - -12231 / 42400,
         11 / 84 - 649 / 6300,
         -1. / 60.,
-    ], dtype=torch.float64),
+    ], dtype=torch.get_default_dtype()),
 )
 
 DPS_C_MID = torch.tensor([
     6025192743 / 30085553152 / 2, 0, 51252292925 / 65400821598 / 2, -2691868925 / 45128329728 / 2,
     187940372067 / 1594534317056 / 2, -1776094331 / 19743644256 / 2, 11237099 / 235043384 / 2
-], dtype=torch.float64)
+], dtype=torch.get_default_dtype())
 
 
 class Dopri5Solver(RKAdaptiveStepsizeODESolver):

--- a/torchdiffeq/_impl/dopri8.py
+++ b/torchdiffeq/_impl/dopri8.py
@@ -61,11 +61,11 @@ C_mid[12] = (- 41.7923486424390588923 * (h**5) + 116.2662185791119533462 * (h**4
 C_mid[13] = (20.3006925822100825485 * (h**5) - 53.9020777466385396792 * (h**4) + 50.2558364226176017553 * (h**3) - 19.0082099341608028453 * (h**2) + 2.3537586759714983486 * h) / (1 / h)
 
 
-A = torch.tensor(A, dtype=torch.float64)
-B = [torch.tensor(B_, dtype=torch.float64) for B_ in B]
-C_sol = torch.tensor(C_sol, dtype=torch.float64)
-C_err = torch.tensor(C_err, dtype=torch.float64)
-_C_mid = torch.tensor(C_mid, dtype=torch.float64)
+A = torch.tensor(A, dtype=torch.get_default_dtype())
+B = [torch.tensor(B_, dtype=torch.get_default_dtype()) for B_ in B]
+C_sol = torch.tensor(C_sol, dtype=torch.get_default_dtype())
+C_err = torch.tensor(C_err, dtype=torch.get_default_dtype())
+_C_mid = torch.tensor(C_mid, dtype=torch.get_default_dtype())
 
 _DOPRI8_TABLEAU = _ButcherTableau(alpha=A, beta=B, c_sol=C_sol, c_error=C_err)
 

--- a/torchdiffeq/_impl/fehlberg2.py
+++ b/torchdiffeq/_impl/fehlberg2.py
@@ -2,18 +2,18 @@ import torch
 from .rk_common import _ButcherTableau, RKAdaptiveStepsizeODESolver
 
 _FEHLBERG2_TABLEAU = _ButcherTableau(
-    alpha=torch.tensor([1 / 2, 1.0], dtype=torch.float64),
+    alpha=torch.tensor([1 / 2, 1.0], dtype=torch.get_default_dtype()),
     beta=[
-        torch.tensor([1 / 2], dtype=torch.float64),
-        torch.tensor([1 / 256, 255 / 256], dtype=torch.float64),
+        torch.tensor([1 / 2], dtype=torch.get_default_dtype()),
+        torch.tensor([1 / 256, 255 / 256], dtype=torch.get_default_dtype()),
     ],
-    c_sol=torch.tensor([1 / 512, 255 / 256, 1 / 512], dtype=torch.float64),
+    c_sol=torch.tensor([1 / 512, 255 / 256, 1 / 512], dtype=torch.get_default_dtype()),
     c_error=torch.tensor(
-        [-1 / 512, 0, 1 / 512], dtype=torch.float64
+        [-1 / 512, 0, 1 / 512], dtype=torch.get_default_dtype()
     ),
 )
 
-_FE_C_MID = torch.tensor([0.0, 0.5, 0.0], dtype=torch.float64)
+_FE_C_MID = torch.tensor([0.0, 0.5, 0.0], dtype=torch.get_default_dtype())
 
 
 class Fehlberg2(RKAdaptiveStepsizeODESolver):

--- a/torchdiffeq/_impl/fixed_adams.py
+++ b/torchdiffeq/_impl/fixed_adams.py
@@ -146,10 +146,16 @@ _DIVISOR = [
     31384184832000, 62768369664000, 32011868528640000, 64023737057280000, 51090942171709440000, 102181884343418880000
 ]
 
-_BASHFORTH_DIVISOR = [torch.tensor([b / divisor for b in bashforth], dtype=torch.float64)
-                      for bashforth, divisor in zip(_BASHFORTH_COEFFICIENTS, _DIVISOR)]
-_MOULTON_DIVISOR = [torch.tensor([m / divisor for m in moulton], dtype=torch.float64)
-                    for moulton, divisor in zip(_MOULTON_COEFFICIENTS, _DIVISOR)]
+_BASHFORTH_DIVISOR = [
+    torch.tensor([b / divisor for b in bashforth],
+                 dtype=torch.get_default_dtype())
+    for bashforth, divisor in zip(_BASHFORTH_COEFFICIENTS, _DIVISOR)
+]
+_MOULTON_DIVISOR = [
+    torch.tensor([m / divisor for m in moulton],
+                 dtype=torch.get_default_dtype())
+    for moulton, divisor in zip(_MOULTON_COEFFICIENTS, _DIVISOR)
+]
 
 _MIN_ORDER = 4
 _MAX_ORDER = 12

--- a/torchdiffeq/_impl/rk_common.py
+++ b/torchdiffeq/_impl/rk_common.py
@@ -152,7 +152,7 @@ class RKAdaptiveStepsizeODESolver(AdaptiveStepsizeEventODESolver):
                  ifactor=10.0,
                  dfactor=0.2,
                  max_num_steps=2 ** 31 - 1,
-                 dtype=torch.float64,
+                 dtype=torch.get_default_dtype(),
                  **kwargs):
         super(RKAdaptiveStepsizeODESolver, self).__init__(dtype=dtype, y0=y0, **kwargs)
 


### PR DESCRIPTION
This PR sets the default dtype for MPS based accelerators (aka Mac M1 etc), thus allowing use of this library for them.

Without this, the user either gets an unsupported dtype error or has to manually set it themselves. I figured the latter option could be done by `torchdiffeq` directly.