### PR TITLE
Adaptive implicit solvers and sparse Sherman-Morrison iterator

### DIFF
--- a/FURTHER_DOCUMENTATION.md
+++ b/FURTHER_DOCUMENTATION.md
@@ -4,7 +4,7 @@
 
 Adaptive and fixed solvers all support several options. Also shown are their default values.
 
-**Adaptive solvers (dopri8, dopri5, bosh3, adaptive_heun):**<br>
+**Adaptive solvers (dopri8, dopri5, tsit5, bosh3, adaptive_heun):**<br>
 For these solvers, `rtol` and `atol` correspond to the tolerances for accepting/rejecting an adaptive step.
 
 - `first_step=None`: What size the first step of the solver should be; by default this is selected empirically.
@@ -28,6 +28,18 @@ For these solvers, `rtol` and `atol` correspond to the tolerances for accepting/
 - `grid_constructor=None`: A more fine-grained way of setting the steps, by setting these particular locations as the locations of the steps. Should be a callable `func, y0, t -> grid`, transforming the arguments `func, y0, t` of `odeint` into the desired grid (which should be a one dimensional tensor).
 
 - `perturb`: Defaults to False. If True, then automatically add small perturbations to the start and end of each step, so that stepping to discontinuities works. Note that this this may not be efficient when using PyTorch 1.6.0 or earlier.
+
+**Implicit fixed solvers (implicit_euler, implicit_midpoint, trapezoid, radauIIA3, radauIIA5, gl4, gl6, sdirk2, trbdf2):**<br>
+
+All options from adaptive solvers are here as well. Additional parameters also include:
+
+- `max_iters`: The maximum number of Sherman-Morrison iterations to minimize the implicit solution residual.
+
+**Implicit adaptive solvers (adaptive_gl4, adaptive_gl6, kvaerno3, kvaerno4, kvaerno5):**<br>
+
+All options from adaptive solvers are here as well. Additional parameters also include:
+
+- `max_iters`: The maximum number of Sherman-Morrison iterations to minimize the implicit solution residual.
 
 Individual solvers also offer certain options.
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ See example of simulating and differentiating through a bouncing ball in [`examp
 Adaptive-step:
  - `dopri8` Runge-Kutta of order 8 of Dormand-Prince-Shampine.
  - `dopri5` Runge-Kutta of order 5 of Dormand-Prince-Shampine **[default]**.
+ - `tsit5` Tsitouras 5/4 Runge-Kutta method
  - `bosh3` Runge-Kutta of order 3 of Bogacki-Shampine.
  - `fehlberg2` Runge-Kutta-Fehlberg of order 2.
  - `adaptive_heun` Runge-Kutta of order 2.
@@ -103,6 +104,24 @@ Fixed-step:
  - `rk4` Fourth-order Runge-Kutta with 3/8 rule.
  - `explicit_adams` Explicit Adams-Bashforth.
  - `implicit_adams` Implicit Adams-Bashforth-Moulton.
+
+Implicit Fixed-step:
+ - `implicit_euler` Backward Euler method.
+ - `implicit_midpoint` Implicit midpoint method.
+ - `trapezoid` Implicit trapezoidal or Crank-Nicolson method.
+ - `radauIIA3` A-B-L stable fully implicit Runge-Kutta of order 3
+ - `radauIIA5` A-B-L stable fully implicit Runge-Kutta of order 5
+ - `gl4` Gauss-Lengedre 2-stage fully implicit Runge-Kutta of order 4
+ - `gl6` Gauss-Lengedre 2-stage fully implicit Runge-Kutta of order 6
+ - `sdirk2` Singly-diagonally implicit Runge-Kutta of order 2
+ - `trbdf2` Explicit-first singly-diagonally implicit Runge-Kutta of order 2
+
+Implicit Adaptive-step:
+ - `adaptive_gl4` Gauss-Lengedre 2-stage fully implicit Runge-Kutta of order 4
+ - `adaptive_gl6` Gauss-Lengedre 2-stage fully implicit Runge-Kutta of order 6
+ - `kvaerno3` A-L stable explicit-first singly-diagonally implicit Runge-Kutta of order 3
+ - `kvaerno4` A-L stable explicit-first singly-diagonally implicit Runge-Kutta of order 4
+ - `kvaerno5` A-L stable explicit-first singly-diagonally implicit Runge-Kutta of order 5
 
 Additionally, all solvers available through SciPy are wrapped for use with `scipy_solver`.
 

--- a/tests/odeint_tests.py
+++ b/tests/odeint_tests.py
@@ -263,9 +263,9 @@ class TestMinMaxStep(unittest.TestCase):
                             torchdiffeq.odeint(f, y0, t_points, method=method, options=options)
                             # Check min step produces far fewer evaluations
                             if min_step > 0:
-                                self.assertLess(f.nfe, 50)
+                                self.assertLess(f.nfe, 50, f'Using {method} with {options}')
                             else:
-                                self.assertGreater(f.nfe, 100)
+                                self.assertGreater(f.nfe, 100, f'Using {method} with {options}')
 
 
 class _NeuralF(torch.nn.Module):

--- a/tests/problems.py
+++ b/tests/problems.py
@@ -70,9 +70,13 @@ FIXED_EXPLICIT_METHODS = ('euler', 'midpoint', 'heun2', 'heun3', 'rk4', 'explici
 FIXED_IMPLICIT_METHODS = ('implicit_euler', 'implicit_midpoint', 'trapezoid', 'radauIIA3', 'gl4', 'radauIIA5', 'gl6', 'sdirk2', 'trbdf2')
 FIXED_METHODS = FIXED_EXPLICIT_METHODS + FIXED_IMPLICIT_METHODS
 ADAMS_METHODS = ('explicit_adams', 'implicit_adams')
-ADAPTIVE_METHODS = ('adaptive_heun', 'fehlberg2', 'bosh3', 'tsit5', 'dopri5', 'dopri8')
+ADAPTIVE_EXPLICIT_METHODS = ('adaptive_heun', 'fehlberg2', 'bosh3', 'tsit5', 'dopri5', 'dopri8')
+# # Some methods are too slow in the test suite
+# ADAPTIVE_IMPLICIT_METHODS = ('adaptive_gl4', 'adaptive_gl6', 'kvaerno3', 'kvaerno4', 'kvaerno5')
+ADAPTIVE_IMPLICIT_METHODS = ('kvaerno3', )
+ADAPTIVE_METHODS = ADAPTIVE_EXPLICIT_METHODS + ADAPTIVE_IMPLICIT_METHODS
 SCIPY_METHODS = ('scipy_solver',)
-IMPLICIT_METHODS = FIXED_IMPLICIT_METHODS
+IMPLICIT_METHODS = FIXED_IMPLICIT_METHODS + ADAPTIVE_IMPLICIT_METHODS
 METHODS = FIXED_METHODS + ADAPTIVE_METHODS + SCIPY_METHODS
 
 

--- a/torchdiffeq/_impl/adaptive_implicit.py
+++ b/torchdiffeq/_impl/adaptive_implicit.py
@@ -1,0 +1,252 @@
+import torch
+from .rk_common import _ButcherTableau
+from .rk_common import FIRKAdaptiveStepsizeODESolver, DIRKAdaptiveStepsizeODESolver
+
+_sqrt_3 = torch.sqrt(torch.tensor(3, dtype=torch.float64)).item()
+_sqrt_15 = torch.sqrt(torch.tensor(15, dtype=torch.float64)).item()
+
+def polyval(coeffs: list, x: float):
+    """
+    Evaluate a polynomial for a given x.
+    Degree is len(coeffs)-1
+
+    Args:
+        coeffs (list): list of coefficients from highest power to constant
+
+        x (float): number to evaluate at
+    """
+    max_degree = len(coeffs) - 1
+    return sum(coeffs[i] * (x**(max_degree-i)) for i in range(len(coeffs)))
+
+_GAUSS_LEGENDRE_4_TABLEAU = _ButcherTableau(
+    alpha=torch.tensor([1 / 2 - _sqrt_3 / 6, 1 / 2 + _sqrt_3 / 6], dtype=torch.float64),
+    beta=[
+        torch.tensor([1 / 4, 1 / 4 - _sqrt_3 / 6], dtype=torch.float64),
+        torch.tensor([1 / 4 + _sqrt_3 / 6, 1 / 4], dtype=torch.float64),
+    ],
+    c_sol=torch.tensor([1 / 2, 1 / 2], dtype=torch.float64),
+    c_error=torch.tensor([1 / 2 + _sqrt_3 / 2, 1 / 2 - _sqrt_3 / 2], dtype=torch.float64),
+)
+
+_GL4_C_MID = torch.tensor([1 / 4 + _sqrt_3 / 8, 1 / 4 - _sqrt_3 / 8], dtype=torch.float64)
+
+class AdaptiveGaussLegendre4(FIRKAdaptiveStepsizeODESolver):
+    order = 4
+    tableau = _GAUSS_LEGENDRE_4_TABLEAU
+    mid = _GL4_C_MID
+
+_GAUSS_LEGENDRE_6_TABLEAU = _ButcherTableau(
+    alpha=torch.tensor([1 / 2 - _sqrt_15 / 10, 1 / 2, 1 / 2 + _sqrt_15 / 10], dtype=torch.float64),
+    beta=[
+        torch.tensor([5 / 36                , 2 / 9 - _sqrt_15 / 15, 5 / 36 - _sqrt_15 / 30], dtype=torch.float64),
+        torch.tensor([5 / 36 + _sqrt_15 / 24, 2 / 9                , 5 / 36 - _sqrt_15 / 24], dtype=torch.float64),
+        torch.tensor([5 / 36 + _sqrt_15 / 30, 2 / 9 + _sqrt_15 / 15, 5 / 36                ], dtype=torch.float64),
+    ],
+    c_sol=torch.tensor([5 / 18, 4 / 9, 5 / 18], dtype=torch.float64),
+    c_error=torch.tensor([-5 / 6, 8 / 3, -5 / 6], dtype=torch.float64),
+)
+
+_GL6_C_MID = torch.tensor([-5 / 18, 19 / 18, -5 / 18], dtype=torch.float64)
+
+class AdaptiveGaussLegendre6(FIRKAdaptiveStepsizeODESolver):
+    order = 6
+    tableau = _GAUSS_LEGENDRE_6_TABLEAU
+    mid = _GL6_C_MID
+
+# https://github.com/patrick-kidger/diffrax/blob/main/diffrax/_solver/kvaerno3.py
+gamma = 0.43586652150
+b31 = (-4 * gamma**2 + 6 * gamma - 1) / (4 * gamma)
+b32 = (-2 * gamma + 1) / (4 * gamma)
+b41 = (6 * gamma - 1) / (12 * gamma)
+b42 = -1 / ((24 * gamma - 12) * gamma)
+b43 = (-6 * gamma**2 + 6 * gamma - 1) / (6 * gamma - 3)
+_KVAERNO_3_TABLEAU = _ButcherTableau(
+    alpha=torch.tensor([0, 2 * gamma, 1.0, 1.0], dtype=torch.float64),
+    beta = [
+        torch.tensor([0], dtype=torch.float64),
+        torch.tensor([gamma, gamma], dtype=torch.float64),
+        torch.tensor([b31, b32, gamma], dtype=torch.float64),
+        torch.tensor([b41, b42, b43, gamma], dtype=torch.float64),
+    ],
+    c_sol=torch.tensor([b41, b42, b43, gamma], dtype=torch.float64),
+    c_error=torch.tensor([b41 - b31, b42 - b32, b43 - gamma, gamma])
+)
+
+_KV3_C_MID = torch.tensor([0.35414591, 0.08861962, 0.09340915, -0.03617468], dtype=torch.float64)
+
+class Kvaerno3(DIRKAdaptiveStepsizeODESolver):
+    order = 3
+    tableau = _KVAERNO_3_TABLEAU
+    mid = _KV3_C_MID
+
+gamma = 0.5728160625
+b31 = polyval([144,-180,81,-15,1,0], gamma) / polyval([12,-6,1], gamma)
+b32 = polyval([-36,39,-15,2,0], gamma) / polyval([12,-6,1], gamma)
+b41 = polyval([-144,396,-330,117,18,1], gamma) / 12 / gamma / gamma / polyval([12,-9,0], gamma)
+b42 = polyval([72,-126,69,-15,1], gamma) / (12*gamma*gamma) / (3*gamma - 1)
+b43 = polyval([-6,6,-1], gamma) * polyval([12,-6,1], gamma) / (12*gamma*gamma) / polyval([12,-9,2], gamma) / (3*gamma -1)
+b51 = polyval([288,-312,120,-18,1], gamma) / (48*gamma*gamma) / polyval([12,-9,2], gamma)
+b52 = polyval([24,-12,1], gamma) / (48*gamma*gamma) / (3*gamma - 1)
+b53 = -(polyval([12,-6,1], gamma)**3) / (48*gamma*gamma) / (3*gamma - 1) / polyval([12,-9,2], gamma) / polyval([6,-6,1], gamma)
+b54 = polyval([-24,36,-12,1], gamma) / polyval([24,-24,4], gamma)
+alpha3 = gamma + b31 + b32
+_KVAERNO_4_TABLEAU = _ButcherTableau(
+    alpha=torch.tensor([0, 2 * gamma, alpha3, 1.0, 1.0], dtype=torch.float64),
+    beta = [
+        torch.tensor([0], dtype=torch.float64),
+        torch.tensor([gamma, gamma], dtype=torch.float64),
+        torch.tensor([b31, b32, gamma], dtype=torch.float64),
+        torch.tensor([b41, b42, b43, gamma], dtype=torch.float64),
+        torch.tensor([b51, b52, b53, b54, gamma], dtype=torch.float64),
+    ],
+    c_sol=torch.tensor([b51, b52, b53, b54, gamma], dtype=torch.float64),
+    c_error=torch.tensor([b51 - b41, b52 - b42, b53 - b43, b54 - gamma, gamma])
+)
+
+# # Solve for C_MID
+# import numpy as np
+# def polyval(coeffs: list, x: float):
+#     """
+#     Evaluate a polynomial for a given x.
+#     Degree is len(coeffs)-1
+
+#     Args:
+#         coeffs (list): list of coefficients from highest power to constant
+
+#         x (float): number to evaluate at
+#     """
+#     max_degree = len(coeffs) - 1
+#     return sum(coeffs[i] * (x**(max_degree-i)) for i in range(len(coeffs)))
+
+# gamma = 0.5728160625
+# b31 = polyval([144,-180,81,-15,1,0], gamma) / polyval([12,-6,1], gamma)
+# b32 = polyval([-36,39,-15,2,0], gamma) / polyval([12,-6,1], gamma)
+# alpha3 = gamma + b31 + b32
+
+# def compute_kvaerno4_midpoint_weights(gamma_val=0.2500000000000000):
+#     """
+#     Computes the midpoint evaluation weights (alpha) for the 4th-order 
+#     Kværnø ESDIRK method at step fraction theta = 0.5.
+    
+#     Parameters:
+#     gamma_val (float): Diagonally implicit parameter matching the solver configuration.
+#                        Defaults to Kværnø's canonical 4th-order root (~0.25).
+#     """
+#     # 1. Define the 5 method nodes (c) based on the implicit parameter gamma
+#     c1 = 0.0
+#     c2 = 2.0 * gamma_val
+#     c3 = alpha3
+#     c4 = 1.0 - gamma_val
+#     c5 = 1.0
+#     nodes = [c1, c2, c3, c4, c5]
+    
+#     # 2. Construct the Vandermonde matrix for the algebraic order conditions (Orders 1 to 4)
+#     # Rows represent: Order 1 (\theta^1), Order 2 (\theta^2), Order 3 (\theta^3), Order 4 (\theta^4)
+#     V = np.array([
+#         [1.0,   1.0,   1.0,   1.0,   1.0],
+#         [c1,    c2,    c3,    c4,    c5],
+#         [c1**2, c2**2, c3**2, c4**2, c5**2],
+#         [c1**3, c2**3, c3**3, c4**3, c5**3]
+#     ])
+    
+#     # 3. Define the target integrated values evaluated exactly at the midpoint (\theta = 1/2)
+#     # The right-hand side corresponds to: \theta^p / p  => [ 1/2, 1/8, 1/24, 1/64 ]
+#     b = np.array([1/2, 1/8, 1/24, 1/64])
+    
+#     # 4. Resolve the system
+#     # Since there are 5 stages and 4 constraint equations, we utilize the Moore-Penrose 
+#     # pseudo-inverse to isolate the minimum-norm solution for the algebraic extension.
+#     alpha_weights = np.linalg.pinv(V) @ b
+    
+#     # Print results out clearly for the console
+#     print(f"--- Kværnø 4th-Order Midpoint Derivation ---")
+#     print(f"Implicit Gamma (gamma): {gamma_val:.6f}\n")
+#     print(f"Stage Nodes (c_i):")
+#     for i, node in enumerate(nodes, 1):
+#         print(f"  c_{i} = {node:.6f}")
+        
+#     print(f"\nCalculated Midpoint Weights (alpha_i):")
+#     for i, weight in enumerate(alpha_weights, 1):
+#         print(f"  alpha_{i} = {weight:.8f}")
+        
+#     return nodes, alpha_weights
+
+# # Execute the weight computation
+# nodes, weights = compute_kvaerno4_midpoint_weights(gamma)
+
+_KV4_C_MID = torch.tensor([0.16574835, 0.10455361, 0.06864508, 0.34505977, -0.18400681], dtype=torch.float64)
+
+class Kvaerno4(DIRKAdaptiveStepsizeODESolver):
+    order = 4
+    tableau = _KVAERNO_4_TABLEAU
+    mid = _KV4_C_MID
+
+_KVAERNO_5_TABLEAU = _ButcherTableau(
+    alpha=torch.tensor([0, 0.52, 1.230333209967908, 0.8957659843500759, 0.43639360985864756, 1.0, 1.0], dtype=torch.float64),
+    beta = [
+        torch.tensor([0], dtype=torch.float64),
+        torch.tensor([0.26, 0.26], dtype=torch.float64),
+        torch.tensor([0.13, 0.84033320996790809, 0.26], dtype=torch.float64),
+        torch.tensor([0.22371961478320505, 0.47675532319799699, -0.06470895363112615, 0.26], dtype=torch.float64),
+        torch.tensor([0.16648564323248321, 0.10450018841591720, 0.03631482272098715, -0.13090704451073998, 0.26], dtype=torch.float64),
+        torch.tensor([0.13855640231268224, 0, -0.04245337201752043, 0.02446657898003141, 0.61943039072480676, 0.26], dtype=torch.float64),
+        torch.tensor([0.13659751177640291, 0, -0.05496908796538376, -0.04118626728321046, 0.62993304899016403, 0.06962479448202728, 0.26], dtype=torch.float64),
+    ],
+    c_sol=torch.tensor([0.13659751177640291, 0, -0.05496908796538376, -0.04118626728321046, 0.62993304899016403, 0.06962479448202728, 0.26], dtype=torch.float64),
+    c_error=(
+        torch.tensor([0.13659751177640291, 0, -0.05496908796538376, -0.04118626728321046, 0.62993304899016403, 0.06962479448202728, 0.26], dtype=torch.float64)-
+        torch.tensor([0.13855640231268224, 0, -0.04245337201752043, 0.02446657898003141, 0.61943039072480676, 0.26, 0], dtype=torch.float64)
+    )
+)
+
+# # Solve for C_MID
+# import numpy as np
+
+# def compute_kvaerno5_midpoint_weights():
+#     """
+#     Computes the midpoint evaluation weights (alpha) for the 5th-order 
+#     Kværnø ESDIRK method at step fraction theta = 0.5.
+#     """
+#     # 1. Define the 5 method nodes (c) based on the implicit parameter gamma
+#     c = [0, 0.52, 1.230333209967908, 0.8957659843500759, 0.43639360985864756, 1.0, 1.0]
+#     nodes = [c_val for c_val in c]
+    
+#     # 2. Construct the Vandermonde matrix for the algebraic order conditions (Orders 1 to 4)
+#     # Rows represent: Order 1 (\theta^1), Order 2 (\theta^2), Order 3 (\theta^3), Order 4 (\theta^4)
+#     V = np.array([
+#         [c_val**0 for c_val in c],
+#         [c_val**1 for c_val in c],
+#         [c_val**2 for c_val in c],
+#         [c_val**3 for c_val in c],
+#         [c_val**4 for c_val in c],
+#     ])
+    
+#     # 3. Define the target integrated values evaluated exactly at the midpoint (\theta = 1/2)
+#     # The right-hand side corresponds to: \theta^p / p  => [ 1/2, 1/8, 1/24, 1/64, 1/160 ]
+#     b = np.array([1/2, 1/8, 1/24, 1/64, 1/160])
+    
+#     # 4. Resolve the system
+#     alpha_weights = np.linalg.pinv(V) @ b
+    
+#     # Print results out clearly for the console
+#     print(f"--- Kværnø 5th-Order Midpoint Derivation ---")
+#     print(f"Implicit Gamma (gamma): {0.26:.6f}\n")
+#     print(f"Stage Nodes (c_i):")
+#     for i, node in enumerate(nodes, 1):
+#         print(f"  c_{i} = {node:.6f}")
+        
+#     print(f"\nCalculated Midpoint Weights (alpha_i):")
+#     for i, weight in enumerate(alpha_weights, 1):
+#         print(f"  alpha_{i} = {weight:.8f}")
+        
+#     return nodes, alpha_weights
+
+# # Execute the weight computation
+# nodes, weights = compute_kvaerno5_midpoint_weights()
+
+_KV5_C_MID = torch.tensor([0.13733277, -0.23363423, -0.07209358, -0.50521749, 0.68463909, 0.24448673, 0.24448673], dtype=torch.float64)
+
+class Kvaerno5(DIRKAdaptiveStepsizeODESolver):
+    order = 5
+    tableau = _KVAERNO_5_TABLEAU
+    mid = _KV5_C_MID

--- a/torchdiffeq/_impl/fixed_grid_implicit.py
+++ b/torchdiffeq/_impl/fixed_grid_implicit.py
@@ -34,8 +34,22 @@ class ImplicitMidpoint(FixedGridFIRKODESolver):
     order = 2
     tableau = _IMPLICIT_MIDPOINT_TABLEAU
 
+_TRAPEZOID_TABLEAU = _ButcherTableau(
+    alpha=torch.tensor([0, 1], dtype=torch.float64),
+    beta=[
+        torch.tensor([0], dtype=torch.float64),
+        torch.tensor([1 /2, 1 / 2], dtype=torch.float64),
+    ],
+    c_sol=torch.tensor([1 / 2, 1 / 2], dtype=torch.float64),
+    c_error=torch.tensor([], dtype=torch.float64),
+)
+
+class Trapezoid(FixedGridDIRKODESolver):
+    order = 2
+    tableau = _TRAPEZOID_TABLEAU
+
 _GAUSS_LEGENDRE_4_TABLEAU = _ButcherTableau(
-    alpha=torch.tensor([1 / 2 - _sqrt_3 / 6, 1 / 2 - _sqrt_3 / 6], dtype=torch.float64),
+    alpha=torch.tensor([1 / 2 - _sqrt_3 / 6, 1 / 2 + _sqrt_3 / 6], dtype=torch.float64),
     beta=[
         torch.tensor([1 / 4, 1 / 4 - _sqrt_3 / 6], dtype=torch.float64),
         torch.tensor([1 / 4 + _sqrt_3 / 6, 1 / 4], dtype=torch.float64),
@@ -43,21 +57,6 @@ _GAUSS_LEGENDRE_4_TABLEAU = _ButcherTableau(
     c_sol=torch.tensor([1 / 2, 1 / 2], dtype=torch.float64),
     c_error=torch.tensor([], dtype=torch.float64),
 )
-
-_TRAPEZOID_TABLEAU = _ButcherTableau(
-    alpha=torch.tensor([0, 1], dtype=torch.float64),
-    beta=[
-        torch.tensor([0, 0], dtype=torch.float64),
-        torch.tensor([1 /2, 1 / 2], dtype=torch.float64),
-    ],
-    c_sol=torch.tensor([1 / 2, 1 / 2], dtype=torch.float64),
-    c_error=torch.tensor([], dtype=torch.float64),
-)
-
-class Trapezoid(FixedGridFIRKODESolver):
-    order = 2
-    tableau = _TRAPEZOID_TABLEAU
-
 
 class GaussLegendre4(FixedGridFIRKODESolver):
     order = 4

--- a/torchdiffeq/_impl/odeint.py
+++ b/torchdiffeq/_impl/odeint.py
@@ -10,6 +10,8 @@ from .fixed_grid_implicit import GaussLegendre4, GaussLegendre6
 from .fixed_grid_implicit import RadauIIA3, RadauIIA5
 from .fixed_grid_implicit import SDIRK2, TRBDF2
 from .fixed_adams import AdamsBashforth, AdamsBashforthMoulton
+from .adaptive_implicit import AdaptiveGaussLegendre4, AdaptiveGaussLegendre6
+from .adaptive_implicit import Kvaerno3, Kvaerno4, Kvaerno5
 from .dopri8 import Dopri8Solver
 from .tsit5 import Tsit5Solver
 from .scipy_wrapper import ScipyWrapperODESolver
@@ -39,6 +41,11 @@ SOLVERS = {
     'gl6': GaussLegendre6,
     'sdirk2': SDIRK2,
     'trbdf2': TRBDF2,
+    'adaptive_gl4': AdaptiveGaussLegendre4,
+    'adaptive_gl6': AdaptiveGaussLegendre6,
+    'kvaerno3': Kvaerno3,
+    'kvaerno4': Kvaerno4,
+    'kvaerno5': Kvaerno5,
     # Backward compatibility: use the same name as before
     'fixed_adams': AdamsBashforthMoulton,
     # ~Backwards compatibility

--- a/torchdiffeq/_impl/rk_common.py
+++ b/torchdiffeq/_impl/rk_common.py
@@ -380,33 +380,9 @@ class FixedGridFIRKODESolver(FixedGridODESolver):
     tableau: _ButcherTableau
 
     def __init__(self, func, y0, step_size=None, grid_constructor=None, interp='linear', perturb=False, max_iters=100, **unused_kwargs):
+        super(FixedGridFIRKODESolver, self).__init__(func, y0, step_size, grid_constructor, interp, perturb, **unused_kwargs)
 
         self.max_iters = max_iters
-        self.atol = unused_kwargs.pop('atol')
-        unused_kwargs.pop('rtol', None)
-        unused_kwargs.pop('norm', None)
-        _handle_unused_kwargs(self, unused_kwargs)
-        del unused_kwargs
-
-        self.func = func
-        self.y0 = y0
-        self.dtype = y0.dtype
-        self.device = y0.device
-        self.step_size = step_size
-        self.interp = interp
-        self.perturb = perturb
-
-        if step_size is None:
-            if grid_constructor is None:
-                self.grid_constructor = lambda f, y0, t: t
-            else:
-                self.grid_constructor = grid_constructor
-        else:
-            if grid_constructor is None:
-                self.grid_constructor = self._grid_constructor_from_step_size(step_size)
-            else:
-                raise ValueError("step_size and grid_constructor are mutually exclusive arguments.")
-            
         self.tableau = _ButcherTableau(alpha=self.tableau.alpha.to(device=self.device, dtype=y0.dtype),
                                        beta=[b.to(device=self.device, dtype=y0.dtype) for b in self.tableau.beta],
                                        c_sol=self.tableau.c_sol.to(device=self.device, dtype=y0.dtype),
@@ -438,17 +414,24 @@ class FixedGridFIRKODESolver(FixedGridODESolver):
         # Broyden's Method to solve the system of nonlinear equations
         y = torch.matmul(k, beta * dt).add(y0.unsqueeze(-1)).movedim(-1, 0)
         f = self._residual(func, k, y, t0, dt, t1)
-        J = torch.ones_like(f).diag()
+        values = torch.ones_like(f)
+        indices = torch.arange(values.numel(), dtype=torch.int64, device=values.device)
+        indices = torch.stack((indices, indices))
+        size = (f.numel(), f.numel())
+        Jinv = torch.sparse_coo_tensor(indices, values, size).coalesce() # Sherman-Morrison Good Method
+
         converged = False
+        dense_update = False
         for _ in range(self.max_iters):
-            if torch.linalg.norm(f, 2) < tol:
+            if (
+                (torch.linalg.vector_norm(f) < (tol * torch.linalg.vector_norm(k))) or
+                (torch.linalg.vector_norm(f) < (tol * tol))
+            ):
                 converged = True
                 break
 
-            # If the matrix becomes singular, just stop and return the last value
-            try:
-                s = -torch.linalg.solve(J, f)
-            except torch._C._LinAlgError:
+            s = -torch.sparse.mm(Jinv, f.unsqueeze(1)).squeeze(1)
+            if not torch.all(torch.isfinite(s)):
                 break
 
             k = k + s.reshape_as(k)
@@ -456,7 +439,18 @@ class FixedGridFIRKODESolver(FixedGridODESolver):
             newf = self._residual(func, k, y, t0, dt, t1)
             z = newf - f
             f = newf
-            J = J + (torch.outer ((z - torch.linalg.vecdot(J,s)),s)) / (torch.dot(s,s))
+
+            sJinv = torch.sparse.mm(Jinv.t(), s.unsqueeze(1)).squeeze(1)
+
+            if dense_update:
+                update = (torch.outer((s - torch.sparse.mm(Jinv, z.unsqueeze(1)).squeeze(1)), sJinv)) / (torch.dot(sJinv, z))
+                update = update.to_sparse()
+            else:
+                # Only update nonzero elements
+                update = torch.mul((s - torch.sparse.mm(Jinv, z.unsqueeze(1)).squeeze(1))[Jinv.indices()[0,:]], sJinv[Jinv.indices()[1,:]]) / (torch.dot(sJinv, z))
+                update = torch.sparse_coo_tensor(Jinv.indices(), update, size)
+
+            Jinv = (Jinv + update).coalesce()
 
         if not converged:
             warnings.warn('Functional iteration did not converge. Solution may be incorrect.')
@@ -505,7 +499,7 @@ class FixedGridDIRKODESolver(FixedGridFIRKODESolver):
         dt = dt.to(t_dtype)
         t1 = t1.to(t_dtype)
 
-        k = [f0.clone()] * len(self.tableau.alpha)
+        k = [f0.clone() for _ in range(len(self.tableau.alpha))]
 
         for i, (alpha_i, beta_i) in enumerate(zip(self.tableau.alpha, self.tableau.beta)):
             perturb = Perturb.NONE
@@ -525,17 +519,24 @@ class FixedGridDIRKODESolver(FixedGridFIRKODESolver):
             # Broyden's Method to solve the system of nonlinear equations
             y_i = torch.matmul(k_i, beta_i * dt).add(y0)
             f = self._residual(func, k_i, y_i, ti, perturb)
-            J = torch.ones_like(f).diag()
+            values = torch.ones_like(f)
+            indices = torch.arange(values.numel(), dtype=torch.int64, device=values.device)
+            indices = torch.stack((indices, indices))
+            size = (f.numel(), f.numel())
+            Jinv = torch.sparse_coo_tensor(indices, values, size).coalesce() # Sherman-Morrison Good Method
+
             converged = False
+            dense_update = False
             for _ in range(self.max_iters):
-                if torch.linalg.norm(f, 2) < tol:
+                if (
+                    (torch.linalg.vector_norm(f) < (tol * torch.linalg.vector_norm(k[i].unsqueeze(-1)))) or
+                    (torch.linalg.vector_norm(f) < (tol * tol))
+                ):
                     converged = True
                     break
 
-                # If the matrix becomes singular, just stop and return the last value
-                try:
-                    s = -torch.linalg.solve(J, f)
-                except torch._C._LinAlgError:
+                s = -torch.sparse.mm(Jinv, f.unsqueeze(1)).squeeze(1)
+                if not torch.all(torch.isfinite(s)):
                     break
 
                 k[i] = k[i] + s.reshape_as(k[i])
@@ -544,7 +545,18 @@ class FixedGridDIRKODESolver(FixedGridFIRKODESolver):
                 newf = self._residual(func, k_i, y_i, ti, perturb)
                 z = newf - f
                 f = newf
-                J = J + (torch.outer ((z - torch.linalg.vecdot(J,s)),s)) / (torch.dot(s,s))
+
+                sJinv = torch.sparse.mm(Jinv.t(), s.unsqueeze(1)).squeeze(1)
+
+                if dense_update:
+                    update = (torch.outer((s - torch.sparse.mm(Jinv, z.unsqueeze(1)).squeeze(1)), sJinv)) / (torch.dot(sJinv, z))
+                    update = update.to_sparse()
+                else:
+                    # Only update nonzero elements
+                    update = torch.mul((s - torch.sparse.mm(Jinv, z.unsqueeze(1)).squeeze(1))[Jinv.indices()[0,:]], sJinv[Jinv.indices()[1,:]]) / (torch.dot(sJinv, z))
+                    update = torch.sparse_coo_tensor(Jinv.indices(), update, size)
+
+                Jinv = (Jinv + update).coalesce()
 
             if not converged:
                 warnings.warn('Functional iteration did not converge. Solution may be incorrect.')
@@ -552,6 +564,318 @@ class FixedGridDIRKODESolver(FixedGridFIRKODESolver):
         dy = torch.matmul(torch.stack(k, -1), dt * self.tableau.c_sol)
 
         return dy, f0
+    
+    def _residual(self, func, K, y, t, perturb):
+        res = K[...,-1] - func(t, y, perturb=perturb)
+        return res.flatten()
+
+class FIRKAdaptiveStepsizeODESolver(RKAdaptiveStepsizeODESolver):
+    order: int
+    tableau: _ButcherTableau
+    mid: torch.Tensor
+
+    def __init__(self, func, y0, rtol, atol,
+                 min_step=0,
+                 max_step=float('inf'),
+                 first_step=None,
+                 step_t=None,
+                 jump_t=None,
+                 safety=0.9,
+                 ifactor=10.0,
+                 dfactor=0.2,
+                 max_num_steps=2 ** 31 - 1,
+                 dtype=torch.float64,
+                 max_iters=100,
+                 **kwargs):
+        super(FIRKAdaptiveStepsizeODESolver, self).__init__(
+            func, y0, rtol, atol,
+            min_step,
+            max_step,
+            first_step,
+            step_t,
+            jump_t,
+            safety,
+            ifactor,
+            dfactor,
+            max_num_steps,
+            dtype,
+            **kwargs
+        )
+        self.max_iters = max_iters
+
+    def _runge_kutta_step(self, func, y0, f0, t0, dt, t1, tableau):
+        if not isinstance(t0, torch.Tensor):
+            t0 = torch.tensor(t0)
+        if not isinstance(dt, torch.Tensor):
+            dt = torch.tensor(dt)
+        if not isinstance(t1, torch.Tensor):
+            t1 = torch.tensor(t1)
+        
+        t_dtype = y0.abs().dtype
+        tol = 1e-8
+        if t_dtype == torch.float64:
+            tol = 1e-8
+        if t_dtype == torch.float32:
+            tol = 1e-6
+
+        t0 = t0.to(t_dtype)
+        dt = dt.to(t_dtype)
+        t1 = t1.to(t_dtype)
+
+        k = f0.clone().unsqueeze(-1).tile(len(tableau.alpha))
+        beta = torch.stack(tableau.beta, -1)
+
+        # Broyden's Method to solve the system of nonlinear equations
+        y = torch.matmul(k, beta * dt).add(y0.unsqueeze(-1)).movedim(-1, 0)
+        f = self._residual(func, k, y, t0, dt, t1)
+        values = torch.ones_like(f)
+        indices = torch.arange(values.numel(), dtype=torch.int64, device=values.device)
+        indices = torch.stack((indices, indices))
+        size = (f.numel(), f.numel())
+        Jinv = torch.sparse_coo_tensor(indices, values, size).coalesce() # Sherman-Morrison Good Method
+
+        converged = False
+        dense_update = False
+        for _ in range(self.max_iters):
+            if (
+                (torch.linalg.vector_norm(f) < (tol * torch.linalg.vector_norm(k))) or
+                (torch.linalg.vector_norm(f) < (tol * tol))
+            ):
+                converged = True
+                break
+
+            s = -torch.sparse.mm(Jinv, f.unsqueeze(1)).squeeze(1)
+            if not torch.all(torch.isfinite(s)):
+                break
+
+            k = k + s.reshape_as(k)
+            y = torch.matmul(k, beta * dt).add(y0.unsqueeze(-1)).movedim(-1, 0)
+            newf = self._residual(func, k, y, t0, dt, t1)
+            z = newf - f
+            f = newf
+
+            sJinv = torch.sparse.mm(Jinv.t(), s.unsqueeze(1)).squeeze(1)
+
+            if dense_update:
+                update = (torch.outer((s - torch.sparse.mm(Jinv, z.unsqueeze(1)).squeeze(1)), sJinv)) / (torch.dot(sJinv, z))
+                update = update.to_sparse()
+            else:
+                # Only update nonzero elements
+                update = torch.mul((s - torch.sparse.mm(Jinv, z.unsqueeze(1)).squeeze(1))[Jinv.indices()[0,:]], sJinv[Jinv.indices()[1,:]]) / (torch.dot(sJinv, z))
+                update = torch.sparse_coo_tensor(Jinv.indices(), update, size)
+
+            Jinv = (Jinv + update).coalesce()
+
+        if not converged:
+            warnings.warn('Functional iteration did not converge. Solution may be incorrect.')
+
+        y1 = y0 + torch.matmul(k, dt * tableau.c_sol)
+        f1 = k[..., -1]
+        y1_error = torch.sum(k * (dt * tableau.c_error), dim=-1)
+        return y1, f1, y1_error, k
+
+    def _residual(self, func, K, y, t0, dt, t1):
+        res = torch.zeros_like(K)
+        for i, (y_i, alpha_i) in enumerate(zip(y, self.tableau.alpha)):
+            perturb = Perturb.NONE
+            if alpha_i == 1.:
+                ti = t1
+                perturb = Perturb.PREV
+            elif alpha_i == 0.:
+                if not torch.all(self.tableau.beta[i]):
+                    # Same slope as stored so skip
+                    continue
+                ti = t0
+            else:
+                ti = t0 + alpha_i * dt
+            res[...,i] = K[...,i] - func(ti, y_i, perturb=perturb)
+        return res.flatten()
+
+    def _adaptive_step(self, rk_state):
+        """Take an adaptive Runge-Kutta step to integrate the ODE."""
+        y0, f0, _, t0, dt, interp_coeff = rk_state
+        if not torch.isfinite(dt):
+            dt = self.min_step
+        dt = dt.clamp(self.min_step, self.max_step)
+        self.func.callback_step(t0, y0, dt)
+        t1 = t0 + dt
+        # dtypes: self.y0.dtype (probably float32); self.dtype (probably float64)
+        # used for state and timelike objects respectively.
+        # Then:
+        # y0.dtype == self.y0.dtype
+        # f0.dtype == self.y0.dtype
+        # t0.dtype == self.dtype
+        # dt.dtype == self.dtype
+        # for coeff in interp_coeff: coeff.dtype == self.y0.dtype
+
+        ########################################################
+        #                      Assertions                      #
+        ########################################################
+        assert t0 + dt > t0, 'underflow in dt {}'.format(dt.item())
+        assert torch.isfinite(y0).all(), 'non-finite values in state `y`: {}'.format(y0)
+
+        ########################################################
+        #     Make step, respecting prescribed grid points     #
+        ########################################################
+
+        on_step_t = False
+        if len(self.step_t):
+            next_step_t = self.step_t[self.next_step_index]
+            on_step_t = t0 < next_step_t < t0 + dt
+            if on_step_t:
+                t1 = next_step_t
+                dt = t1 - t0
+
+        on_jump_t = False
+        if len(self.jump_t):
+            next_jump_t = self.jump_t[self.next_jump_index]
+            on_jump_t = t0 < next_jump_t < t0 + dt
+            if on_jump_t:
+                on_step_t = False
+                t1 = next_jump_t
+                dt = t1 - t0
+
+        # Must be arranged as doing all the step_t handling, then all the jump_t handling, in case we
+        # trigger both. (i.e. interleaving them would be wrong.)
+
+        y1, f1, y1_error, k = self._runge_kutta_step(self.func, y0, f0, t0, dt, t1, tableau=self.tableau)
+        # dtypes:
+        # y1.dtype == self.y0.dtype
+        # f1.dtype == self.y0.dtype
+        # y1_error.dtype == self.dtype
+        # k.dtype == self.y0.dtype
+
+        ########################################################
+        #                     Error Ratio                      #
+        ########################################################
+        error_ratio = _compute_error_ratio(y1_error, self.rtol, self.atol, y0, y1, self.norm)
+        accept_step = error_ratio <= 1
+
+        # Handle min max stepping
+        if dt > self.max_step:
+            accept_step = False
+        if dt <= self.min_step:
+            accept_step = True
+
+        # dtypes:
+        # error_ratio.dtype == self.dtype
+
+        ########################################################
+        #                   Update RK State                    #
+        ########################################################
+        if accept_step:
+            self.func.callback_accept_step(t0, y0, dt)
+            t_next = t1
+            y_next = y1
+            interp_coeff = self._interp_fit(y0, y_next, k, dt)
+            if on_step_t:
+                if self.next_step_index != len(self.step_t) - 1:
+                    self.next_step_index += 1
+            if on_jump_t:
+                if self.next_jump_index != len(self.jump_t) - 1:
+                    self.next_jump_index += 1
+                # We've just passed a discontinuity in f; we should update f to match the side of the discontinuity
+                # we're now on.
+                f1 = self.func(t_next, y_next, perturb=Perturb.NEXT)
+            f_next = f1
+        else:
+            self.func.callback_reject_step(t0, y0, dt)
+            t_next = t0
+            y_next = y0
+            f_next = f0
+        dt_next = _optimal_step_size(dt, error_ratio, self.safety, self.ifactor, self.dfactor, self.order)
+        dt_next = dt_next.clamp(self.min_step, self.max_step)
+        rk_state = _RungeKuttaState(y_next, f_next, t0, t_next, dt_next, interp_coeff)
+        return rk_state
+
+class DIRKAdaptiveStepsizeODESolver(FIRKAdaptiveStepsizeODESolver):
+
+    def _runge_kutta_step(self, func, y0, f0, t0, dt, t1, tableau):
+        if not isinstance(t0, torch.Tensor):
+            t0 = torch.tensor(t0)
+        if not isinstance(dt, torch.Tensor):
+            dt = torch.tensor(dt)
+        if not isinstance(t1, torch.Tensor):
+            t1 = torch.tensor(t1)
+        
+        t_dtype = y0.abs().dtype
+        tol = 1e-8
+        if t_dtype == torch.float64:
+            tol = 1e-8
+        if t_dtype == torch.float32:
+            tol = 1e-6
+
+        t0 = t0.to(t_dtype)
+        dt = dt.to(t_dtype)
+        t1 = t1.to(t_dtype)
+
+        k = [f0.clone() for _ in range(len(tableau.alpha))]
+
+        for i, (alpha_i, beta_i) in enumerate(zip(tableau.alpha, tableau.beta)):
+            perturb = Perturb.NONE
+            if alpha_i == 1.:
+                ti = t1
+                perturb = Perturb.PREV
+            elif alpha_i == 0.:
+                if not torch.all(tableau.beta[i]):
+                    # Same slope as stored so skip
+                    continue
+                ti = t0
+            else:
+                ti = t0 + alpha_i * dt
+
+            k_i = torch.stack(k[:i+1], -1)
+
+            # Broyden's Method to solve the system of nonlinear equations
+            y_i = torch.matmul(k_i, beta_i * dt).add(y0)
+            f = self._residual(func, k_i, y_i, ti, perturb)
+            values = torch.ones_like(f)
+            indices = torch.arange(values.numel(), dtype=torch.int64, device=values.device)
+            indices = torch.stack((indices, indices))
+            size = (f.numel(), f.numel())
+            Jinv = torch.sparse_coo_tensor(indices, values, size).coalesce() # Sherman-Morrison Good Method
+
+            converged = False
+            dense_update = False
+            for _ in range(self.max_iters):
+                if (
+                    (torch.linalg.vector_norm(f) < (tol * torch.linalg.vector_norm(k[i].unsqueeze(-1)))) or
+                    (torch.linalg.vector_norm(f) < (tol * tol))
+                ):
+                    converged = True
+                    break
+
+                s = -torch.sparse.mm(Jinv, f.unsqueeze(1)).squeeze(1)
+                if not torch.all(torch.isfinite(s)):
+                    break
+
+                k[i] = k[i] + s.reshape_as(k[i])
+                k_i = torch.stack(k[:i+1], -1)
+                y_i = torch.matmul(k_i, beta_i * dt).add(y0)
+                newf = self._residual(func, k_i, y_i, ti, perturb)
+                z = newf - f
+                f = newf
+
+                sJinv = torch.sparse.mm(Jinv.t(), s.unsqueeze(1)).squeeze(1)
+
+                if dense_update:
+                    update = (torch.outer((s - torch.sparse.mm(Jinv, z.unsqueeze(1)).squeeze(1)), sJinv)) / (torch.dot(sJinv, z))
+                    update = update.to_sparse()
+                else:
+                    # Only update nonzero elements
+                    update = torch.mul((s - torch.sparse.mm(Jinv, z.unsqueeze(1)).squeeze(1))[Jinv.indices()[0,:]], sJinv[Jinv.indices()[1,:]]) / (torch.dot(sJinv, z))
+                    update = torch.sparse_coo_tensor(Jinv.indices(), update, size)
+
+                Jinv = (Jinv + update).coalesce()
+
+            if not converged:
+                warnings.warn('Functional iteration did not converge. Solution may be incorrect.')
+
+        k = torch.stack(k, -1)
+        y1 = y0 + torch.matmul(k, dt * tableau.c_sol)
+        f1 = k[..., -1]
+        y1_error = torch.sum(k * (dt * tableau.c_error), dim=-1)
+        return y1, f1, y1_error, k
     
     def _residual(self, func, K, y, t, perturb):
         res = K[...,-1] - func(t, y, perturb=perturb)


### PR DESCRIPTION
## Big Update

Closes #267 and Closes #214

Adds adaptive step implicit solver methods including:
- `adaptive_gl4`
- `adaptive_gl6`
- `kvaerno3`
- `kvaerno4`
- `kvaerno5`

Only `kvaerno3` was added to the test suite as the others take a long time to evaluate.

Fixed and adaptive fully implicit Runge-Kutta (FIRK) and diagonally implicit Runge-Kutta (DIRK) now use the [good Sherman-Morrison method](https://en.wikipedia.org/wiki/Broyden%27s_method) with a [sparse diagonal Jacobian](https://arxiv.org/abs/2501.17737) to avoid matrix inversion and scale to large problems.

New solvers have been added to `README.MD`  and `FURTHER_DOCUMENTATION.MD`.

*Side Note: `TestMinMaxStep` in `tests/odeint_tests.py` fails with the `scipy_solver` not respecting the `min_step` option in scipy version 1.17.1.*